### PR TITLE
Handle interrupts when applet handler is not running.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/usbarmory/armory-witness-log v0.0.0-20230119085953-e0606f8bd081
 	github.com/usbarmory/crucible v0.0.0-20230117112356-5e0805300e15
 	github.com/usbarmory/imx-usbserial v0.0.0-20230502120132-d12d9c498d30
-	github.com/usbarmory/tamago v0.0.0-20230428114202-5d3b5697bb08
+	github.com/usbarmory/tamago v0.0.0-20230510123840-f282604bc77e
 	golang.org/x/crypto v0.8.0
 	golang.org/x/mod v0.10.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/usbarmory/imx-usbserial v0.0.0-20230502120132-d12d9c498d30/go.mod h1:
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 github.com/usbarmory/tamago v0.0.0-20230428114202-5d3b5697bb08 h1:UT09xzjcUxxwuEG2cUS8p2FXs0CycY9buDGZbFh1fyM=
 github.com/usbarmory/tamago v0.0.0-20230428114202-5d3b5697bb08/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
+github.com/usbarmory/tamago v0.0.0-20230510123840-f282604bc77e h1:Otz9qf59XAsffGLMo77N1ngIRBUE7HJk/RqSGzFT6v0=
+github.com/usbarmory/tamago v0.0.0-20230510123840-f282604bc77e/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=

--- a/trusted_os/handler.s
+++ b/trusted_os/handler.s
@@ -15,9 +15,9 @@
 #include "go_asm.h"
 #include "textflag.h"
 
-TEXT ·wakeAppletHandler(SB),$0-8
-	MOVW	appletHandlerG+0(FP), R0
-	MOVW	appletHandlerP+4(FP), R1
+TEXT ·wakeHandler(SB),$0-8
+	MOVW	handlerG+0(FP), R0
+	MOVW	handlerP+4(FP), R1
 
 	CMP	$0, R0
 	B.EQ	done

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -17,10 +17,8 @@ package main
 import (
 	_ "embed"
 	"log"
-	"math"
 	"os"
 	"runtime"
-	"time"
 
 	usbarmory "github.com/usbarmory/tamago/board/usbarmory/mk2"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
@@ -69,7 +67,7 @@ func init() {
 		imx6ul.DCP.Init()
 	}
 
-	imx6ul.GIC.Init(false, true)
+	imx6ul.GIC.Init(true, false)
 
 	log.Printf("%s/%s (%s) • TEE security monitor (Secure World system/monitor) • %s %s",
 		runtime.GOOS, runtime.GOARCH, runtime.Version(),
@@ -133,16 +131,14 @@ func main() {
 		log.Printf("SM applet verified")
 		usbarmory.LED("white", true)
 
-		// Start the control interface just before applet is loaded as
-		// USB IRQs are served only while it is running.
-		ctl.Start(true)
-
 		if _, err = loadApplet(taELF, ctl); err != nil {
 			log.Printf("SM applet execution error, %v", err)
 		}
-	} else {
-		ctl.Start(false)
 	}
 
-	time.Sleep(math.MaxInt64)
+	// start USB control interface
+	ctl.Start(true)
+
+	// never returns
+	irqHandler()
 }


### PR DESCRIPTION
This fixes lack of USB control interface and watchdog servicing when an applet is not running.