### PR TITLE
support BEE relocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ SIGN = $(shell type -p signify || type -p signify-openbsd || type -p minisign)
 SIGN_PWD ?= "armored-witness"
 
 APP := ""
-TEXT_START := 0x80010000 # ramStart (defined in mem.go under relevant tamago/soc package) + 0x10000
+TEXT_START = 0x80010000 # ramStart (defined in mem.go under relevant tamago/soc package) + 0x10000
+
+ifeq ("${BEE}","1")
+	TEXT_START := 0x10010000
+	BUILD_TAGS := ${BUILD_TAGS},bee
+endif
 
 GOENV := GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=tamago GOARM=7 GOARCH=arm
 ENTRY_POINT := _rt0_arm_tamago
@@ -55,7 +60,6 @@ elf: $(APP).elf
 
 trusted_os: APP=trusted_os
 trusted_os: DIR=$(CURDIR)/trusted_os
-trusted_os: TEXT_START=0x80010000
 trusted_os: check_os_env copy_applet elf imx
 	echo "signing Trusted OS"
 	@if [ "${SIGN_PWD}" != "" ]; then \

--- a/trusted_os/bee.go
+++ b/trusted_os/bee.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !bee
-// +build !bee
+//go:build bee
+// +build bee
 
 package main
 
@@ -23,15 +23,15 @@ import (
 
 const (
 	// Secure Monitor
-	secureStart = 0x80000000 // imx6ul.MMDC_BASE
+	secureStart = 0x10000000 // bee.AliasRegion0
 	secureSize  = 0x0e000000 // 224MB
 
 	// Secure Monitor DMA
-	secureDMAStart = 0x8e000000
+	secureDMAStart = 0x1e000000
 	secureDMASize  = 0x02000000 // 32MB
 
 	// Secure Monitor Applet
-	appletStart = 0x90000000
+	appletStart = 0x20000000
 	appletSize  = 0x10000000 // 256MB
 )
 

--- a/trusted_os/dma.go
+++ b/trusted_os/dma.go
@@ -12,31 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !bee
-// +build !bee
-
 package main
 
 import (
-	_ "unsafe"
+	"github.com/usbarmory/tamago/dma"
 )
 
-const (
-	// Secure Monitor
-	secureStart = 0x80000000 // imx6ul.MMDC_BASE
-	secureSize  = 0x0e000000 // 224MB
+var appletRegion *dma.Region
 
-	// Secure Monitor DMA
-	secureDMAStart = 0x8e000000
-	secureDMASize  = 0x02000000 // 32MB
+func init() {
+	appletRegion, _ = dma.NewRegion(appletStart, appletSize, false)
+	appletRegion.Reserve(appletSize, 0)
 
-	// Secure Monitor Applet
-	appletStart = 0x90000000
-	appletSize  = 0x10000000 // 256MB
-)
-
-//go:linkname ramStart runtime.ramStart
-var ramStart uint32 = secureStart
-
-//go:linkname ramSize runtime.ramSize
-var ramSize uint32 = secureSize
+	dma.Init(secureDMAStart, secureDMASize)
+}

--- a/trusted_os/load.go
+++ b/trusted_os/load.go
@@ -82,7 +82,7 @@ func run(ctx *monitor.ExecCtx) (err error) {
 
 	log.Printf("SM starting mode:%s sp:%#.8x pc:%#.8x ns:%v", mode, ctx.R13, ctx.R15, ns)
 
-	// activate watchdog to prevent resource starvationa
+	// activate watchdog to prevent resource starvation
 	imx6ul.GIC.EnableInterrupt(imx6ul.WDOG1.IRQ, true)
 	imx6ul.WDOG1.EnableInterrupt()
 	imx6ul.WDOG1.EnableTimeout(watchdogTimeout)

--- a/trusted_os/mem_bee.go
+++ b/trusted_os/mem_bee.go
@@ -21,6 +21,9 @@ import (
 	_ "unsafe"
 )
 
+// The following memory regions are within an alias of external DDR, required
+// when memory encryption is enforced by the i.MX6UL Bus Encryption Engine
+// (BEE).
 const (
 	// Secure Monitor
 	secureStart = 0x10000000 // bee.AliasRegion0


### PR DESCRIPTION
This commit supports [amored-witness-boot PR #12](https://github.com/transparency-dev/armored-witness-boot/pull/12) by adding optional compile time flags to support BEE aliased regions.