### PR TITLE
add RPC API for TA RPMB own sector use

### DIFF
--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -130,6 +130,21 @@ func (r *RPC) Read(xfer rpc.Read, out *[]byte) (err error) {
 	return
 }
 
+// WriteRPMB performs an authenticated data transfer to the card RPMB partition
+// sector allocated to the Trusted Applet. The input buffer can contain up to
+// 256 bytes of data, n can be passed to retrieve the partition write counter.
+func (r *RPC) WriteRPMB(buf []byte, n *uint32) (err error) {
+	return r.RPMB.transfer(taUserSector, buf, n, true)
+}
+
+// ReadRPMB performs an authenticated data transfer from the card RPMB
+// partition sector allocated to the Trusted Applet. The input buffer can
+// contain up to 256 bytes of data, n can be set to retrieve the partition
+// write counter.
+func (r *RPC) ReadRPMB(buf []byte, n *uint32) error {
+	return r.RPMB.transfer(taUserSector, buf, n, false)
+}
+
 // DeriveKey derives a hardware unique key in a manner equivalent to PKCS#11
 // C_DeriveKey with CKM_AES_CBC_ENCRYPT_DATA.
 //


### PR DESCRIPTION
This RPC API allows the Trusted Applet to use its own protected sector for arbitrary authenticated data read/write as well as retrieving the RPMB monotonic counter.