### PR TITLE
Trap SYSCALL_EXIT in applet

### DIFF
--- a/trusted_os/handler.go
+++ b/trusted_os/handler.go
@@ -17,6 +17,8 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
+	"runtime/pprof"
 
 	"github.com/usbarmory/tamago/arm"
 	"github.com/usbarmory/tamago/bits"
@@ -109,6 +111,9 @@ func handler(ctx *monitor.ExecCtx) (err error) {
 		return fiqHandler(ctx)
 	case arm.SUPERVISOR:
 		switch ctx.A0() {
+		case syscall.SYS_EXIT:
+			pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
+			return monitor.SecureHandler(ctx)
 		case syscall.SYS_WRITE:
 			return bufferedStdoutLog(byte(ctx.A1()))
 		case RX:

--- a/trusted_os/load.go
+++ b/trusted_os/load.go
@@ -90,6 +90,9 @@ func run(ctx *monitor.ExecCtx) (err error) {
 	// when switching back to System Mode.
 	imx6ul.ARM.EnableInterrupts(false)
 
+	if err != nil {
+		log.Printf("SM applet err: %v", err)
+	}
 	log.Printf("SM applet stopped mode:%s sp:%#.8x lr:%#.8x pc:%#.8x ns:%v", mode, ctx.R13, ctx.R14, ctx.R15, ns)
 
 	return


### PR DESCRIPTION
This allows us to dump stacktraces when the applet exits.

Unfortunately this doesn't currently include situations where `log.Fatal` is called, but should at least include situations where goroutines `ABT`.