### PR TITLE
debug TA file:line on fatal exceptions

### DIFF
--- a/trusted_os/console.go
+++ b/trusted_os/console.go
@@ -38,6 +38,8 @@ import (
 // operations (i.e. stdout/stderr), is overridden with a NOP. Secondarily UART2
 // is disabled at the first opportunity (init()).
 
+const debug = false
+
 func init() {
 	// disable console
 	imx6ul.UART2.Disable()

--- a/trusted_os/debug.go
+++ b/trusted_os/debug.go
@@ -26,6 +26,8 @@ import (
 	"github.com/usbarmory/imx-usbserial"
 )
 
+const debug = true
+
 var serial usbserial.UART
 
 //go:linkname printk runtime.printk

--- a/trusted_os/load.go
+++ b/trusted_os/load.go
@@ -92,5 +92,10 @@ func run(ctx *monitor.ExecCtx) (err error) {
 
 	log.Printf("SM applet stopped mode:%s sp:%#.8x lr:%#.8x pc:%#.8x ns:%v", mode, ctx.R13, ctx.R14, ctx.R15, ns)
 
+	if err != nil && debug {
+		log.Printf("\t%s", fileLine(taELF, ctx.R15))
+		log.Printf("\t%s", fileLine(taELF, ctx.R14))
+	}
+
 	return
 }

--- a/trusted_os/log.go
+++ b/trusted_os/log.go
@@ -16,6 +16,9 @@ package main
 
 import (
 	"bytes"
+	"debug/elf"
+	"debug/gosym"
+	"fmt"
 	"os"
 )
 
@@ -35,4 +38,42 @@ func bufferedStdoutLog(c byte) (err error) {
 	}
 
 	return
+}
+
+func fileLine(buf[]byte, pc uint32) (s string) {
+	exe, err := elf.NewFile(bytes.NewReader(buf))
+
+	if err != nil {
+		return
+	}
+
+	addr := exe.Section(".text").Addr
+
+	lineTableData, err := exe.Section(".gopclntab").Data()
+
+	if err != nil {
+		return
+	}
+
+	lineTable := gosym.NewLineTable(lineTableData, addr)
+
+	if err != nil {
+		return
+	}
+
+	symTableData, err := exe.Section(".gosymtab").Data()
+
+	if err != nil {
+		return
+	}
+
+	symTable, err := gosym.NewTable(symTableData, lineTable)
+
+	if err != nil {
+		return
+	}
+
+	file, line, _ := symTable.PCToLine(uint64(pc))
+
+	return fmt.Sprintf("%s:%d", file, line)
 }


### PR DESCRIPTION
This PR adds logging of `file:line` (only when compiled with `DEBUG=1`) when the Trusted Applet exits ungracefully (e.g. data abort).