### PR TITLE
Update to match Watchdog API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/usbarmory/armory-witness-log v0.0.0-20230119085953-e0606f8bd081
 	github.com/usbarmory/crucible v0.0.0-20230117112356-5e0805300e15
 	github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8
-	github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f
+	github.com/usbarmory/tamago v0.0.0-20230614130306-d64a26341d56
 	golang.org/x/crypto v0.8.0
 	golang.org/x/mod v0.10.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8/go.mod h1:
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f h1:2nCLV3Jp6rFZC6fk34ClkqBTF1IpWBm5dI+bPHxBQkE=
 github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
+github.com/usbarmory/tamago v0.0.0-20230614130306-d64a26341d56 h1:b/pXGtqyJghjfm1LXlATpHtcnF9zs/+4qc3BAqMxmec=
+github.com/usbarmory/tamago v0.0.0-20230614130306-d64a26341d56/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/usbarmory/crucible v0.0.0-20230117112356-5e0805300e15/go.mod h1:8Ctxs
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8 h1:VPruqXJEJxTweSRyx3NIkiIqQl9ppZHp4wZnL8+Y0aI=
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8/go.mod h1:XfTrYj8Ik3ljit1cSHTcsXs7lyJ/QMsplPDX8+g5s7c=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
-github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f h1:2nCLV3Jp6rFZC6fk34ClkqBTF1IpWBm5dI+bPHxBQkE=
-github.com/usbarmory/tamago v0.0.0-20230529110145-b8025086bb9f/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 github.com/usbarmory/tamago v0.0.0-20230614130306-d64a26341d56 h1:b/pXGtqyJghjfm1LXlATpHtcnF9zs/+4qc3BAqMxmec=
 github.com/usbarmory/tamago v0.0.0-20230614130306-d64a26341d56/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/trusted_os/load.go
+++ b/trusted_os/load.go
@@ -27,9 +27,15 @@ import (
 	"github.com/usbarmory/GoTEE/monitor"
 )
 
-// Watchdog interval (in ms) to force context switching (User -> System mode)
-// to prevent Trusted Applet starvation of Trusted OS resources.
-const watchdogTimeout = 60 * 1000
+const (
+	// Watchdog interval (in ms) to force context switching (User -> System mode)
+	// to prevent Trusted Applet starvation of Trusted OS resources.
+	watchdogTimeout = 60 * 1000
+
+	// watchdogWarningInterval (in ms) controls how long before the watchdog triggers
+	// the service request interrupt will be raised.
+	watchdogWarningInterval = 5 * 1000
+)
 
 // loadApplet loads a TamaGo unikernel as trusted applet.
 func loadApplet(elf []byte, ctl *controlInterface) (ta *monitor.ExecCtx, err error) {
@@ -75,7 +81,7 @@ func run(ctx *monitor.ExecCtx) (err error) {
 
 	// activate watchdog to prevent resource starvation
 	imx6ul.GIC.EnableInterrupt(imx6ul.WDOG1.IRQ, true)
-	imx6ul.WDOG1.EnableInterrupt()
+	imx6ul.WDOG1.EnableInterrupt(watchdogWarningInterval)
 	imx6ul.WDOG1.EnableTimeout(watchdogTimeout)
 
 	// route IRQs as FIQs to serve them through applet handler


### PR DESCRIPTION
The Watchdog's `EnableInterrupt` call now takes a parameter specifying how much "notice" to give when generating a service request interrupt before the watchdog itself will trigger.