### PR TITLE
Watchdog forensics

### DIFF
--- a/trusted_os/console.go
+++ b/trusted_os/console.go
@@ -55,3 +55,5 @@ func printk(c byte) {
 func configureUART(device *usb.Device) error {
 	return nil
 }
+
+func watchdogForensics(_ []byte) {}

--- a/trusted_os/debug.go
+++ b/trusted_os/debug.go
@@ -18,9 +18,17 @@
 package main
 
 import (
-	_ "unsafe"
+	"bytes"
+	"debug/elf"
+	"debug/gosym"
+	"encoding/binary"
+	"fmt"
+	"unsafe"
 
+	"github.com/usbarmory/tamago/arm"
 	usbarmory "github.com/usbarmory/tamago/board/usbarmory/mk2"
+	"github.com/usbarmory/tamago/dma"
+	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/usb"
 
 	"github.com/usbarmory/imx-usbserial"
@@ -39,4 +47,169 @@ func printk(c byte) {
 func configureUART(device *usb.Device) (err error) {
 	serial.Device = device
 	return serial.Init()
+}
+
+func watchdogForensics(applet []byte) (string, error) {
+	f, err := elf.NewFile(bytes.NewReader(applet))
+	if err != nil {
+		return "", fmt.Errorf("failed to open ELF: %v", err)
+	}
+
+	syms, err := f.Symbols()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch symbols: %v", err)
+	}
+
+	var allGPtr, allGLen, textStart, textEnd uint32
+	for _, s := range syms {
+		switch t, n := elf.ST_TYPE(s.Info), s.Name; {
+		case t == elf.STT_OBJECT && n == "runtime.allgptr":
+			allGPtr = uint32(s.Value)
+		case t == elf.STT_OBJECT && n == "runtime.allglen":
+			allGLen = uint32(s.Value)
+		case t == elf.STT_FUNC && n == "runtime.text":
+			textStart = uint32(s.Value)
+		case t == elf.STT_FUNC && n == "runtime.etext":
+			textEnd = uint32(s.Value)
+		}
+	}
+
+	r := fmt.Sprintf("watchdogForensics: allGPtr 0x%x allGLen 0x%x textStart 0x%x textEnd 0x%x\n", allGPtr, allGLen, textStart, textEnd)
+	if allGPtr == 0 || allGLen == 0 || textStart == 0 || textEnd == 0 {
+		return "", fmt.Errorf("didn't find all syms, not doing forensics: %s", r)
+	}
+
+	for i := uint32(0); i < allGLen; i++ {
+		gptr := (*uint32)(unsafe.Pointer(uintptr(allGPtr + i*4)))
+
+		if gptr == nil {
+			break
+		}
+
+		g := (*g)(unsafe.Pointer(uintptr(*gptr)))
+
+		if g == nil {
+			break
+		}
+
+		r += fmt.Sprintf("g[%d]: %x\n", i, g)
+
+		if g.m == nil {
+			fmt.Printf("\tsched: %x\n", g.sched)
+		} else {
+			stack := mem(uint(g.stacklo), int(g.stackhi-g.stacklo), nil)
+
+			for i := 0; i < len(stack); i += 4 {
+				try := binary.LittleEndian.Uint32(stack[i : i+4])
+
+				if try >= uint32(textStart) && try <= uint32(textEnd) {
+					if l, err := PCToLine(applet, try); err == nil {
+						r += fmt.Sprintf("\tpotential LR: %s\n", l)
+					}
+				}
+			}
+		}
+	}
+
+	return r, nil
+}
+
+type m struct {
+	g0      *g
+	morebuf gobuf
+}
+
+type gobuf struct {
+	sp   uint32
+	pc   uint32
+	g    uint32
+	ctxt uint32
+	ret  uint32
+	lr   uint32
+	bp   uint32
+}
+
+type g struct {
+	stacklo     uint32
+	stackhi     uint32
+	stackguard0 uint32
+	stackguard1 uint32
+	_panic      uint32
+	_defer      uint32
+	m           *m
+	sched       gobuf
+	syscallsp   uint32
+	syscallpc   uint32
+}
+
+func symTable(buf []byte) (symTable *gosym.Table, err error) {
+	exe, err := elf.NewFile(bytes.NewReader(buf))
+
+	if err != nil {
+		return
+	}
+
+	addr := exe.Section(".text").Addr
+
+	lineTableData, err := exe.Section(".gopclntab").Data()
+
+	if err != nil {
+		return
+	}
+
+	lineTable := gosym.NewLineTable(lineTableData, addr)
+
+	if err != nil {
+		return
+	}
+
+	symTableData, err := exe.Section(".gosymtab").Data()
+
+	if err != nil {
+		return
+	}
+
+	return gosym.NewTable(symTableData, lineTable)
+}
+
+func PCToLine(buf []byte, pc uint32) (s string, err error) {
+	symTable, err := symTable(buf)
+
+	if err != nil {
+		return
+	}
+
+	file, line, _ := symTable.PCToLine(uint64(pc))
+
+	return fmt.Sprintf("%s:%d", file, line), nil
+}
+
+func mem(start uint, size int, w []byte) (b []byte) {
+	// temporarily map page zero if required
+	if z := uint32(1 << 20); uint32(start) < z {
+		imx6ul.ARM.ConfigureMMU(0, z, (arm.TTE_AP_001<<10)|arm.TTE_SECTION)
+		defer imx6ul.ARM.ConfigureMMU(0, z, 0)
+	}
+
+	return memCopy(start, size, w)
+}
+
+func memCopy(start uint, size int, w []byte) (b []byte) {
+	mem, err := dma.NewRegion(start, size, true)
+
+	if err != nil {
+		panic("could not allocate memory copy DMA")
+	}
+
+	start, buf := mem.Reserve(size, 0)
+	defer mem.Release(start)
+
+	if len(w) > 0 {
+		copy(buf, w)
+	} else {
+		b = make([]byte, size)
+		copy(b, buf)
+	}
+
+	return
 }

--- a/trusted_os/debug.go
+++ b/trusted_os/debug.go
@@ -84,7 +84,14 @@ func watchdogForensics(applet []byte) (string, error) {
 		return "", fmt.Errorf("failed to create symbol table: %v", err)
 	}
 
-	for i := uint32(0); i < allGLen; i++ {
+	glenptr := (*uint32)(unsafe.Pointer(uintptr(allGLen)))
+	// We've checking allGLen isn't nil above
+	glen := *glenptr
+	if glen == 0 || glen > 512 {
+		return "", fmt.Errorf("dubious allGLen value %d", glen)
+	}
+
+	for i := uint32(0); i < glen; i++ {
 		gptr := (*uint32)(unsafe.Pointer(uintptr(allGPtr + i*4)))
 
 		if gptr == nil {

--- a/trusted_os/load.go
+++ b/trusted_os/load.go
@@ -30,7 +30,7 @@ import (
 const (
 	// Watchdog interval (in ms) to force context switching (User -> System mode)
 	// to prevent Trusted Applet starvation of Trusted OS resources.
-	watchdogTimeout = 60 * 1000
+	watchdogTimeout = 10 * 1000
 
 	// watchdogWarningInterval (in ms) controls how long before the watchdog triggers
 	// the service request interrupt will be raised.

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -128,22 +128,28 @@ func main() {
 	}
 
 	if len(taELF) != 0 && len(taSig) != 0 {
-		if s, err := watchdogForensics(taELF); err != nil {
+		s, err := watchdogForensics(taELF)
+		if err == nil {
+			usbarmory.LED("white", true)
+			// We have some forensics, keep dumping them out so we can see them.
 			go func() {
-				for i := 10; i > 0; i-- {
-					log.Printf("Forensics in %d", i)
-					time.Sleep(time.Second)
+				for {
+					time.Sleep(5 * time.Second)
+					log.Printf("watchdogForensics:\n%s", s)
 				}
-				log.Printf("watchdogForensics failed: %v", err)
 			}()
-		} else {
 			go func() {
-				for i := 10; i > 0; i-- {
-					log.Printf("Forensics in %d", i)
-					time.Sleep(time.Second)
+				for l := true; ; l = !l {
+					usbarmory.LED("white", l)
+					usbarmory.LED("blue", !l)
+					time.Sleep(100 * time.Millisecond)
 				}
-				log.Printf("watchdogForensics:\n%s", s)
 			}()
+			// but don't start the applet, so we'll block in this func
+			// start USB control interface
+			ctl.Start(true)
+			usbarmory.LED("blue", true)
+			irqHandler()
 		}
 
 		log.Printf("SM applet verification pub:%s", PublicKey)

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -128,6 +128,24 @@ func main() {
 	}
 
 	if len(taELF) != 0 && len(taSig) != 0 {
+		if s, err := watchdogForensics(taELF); err != nil {
+			go func() {
+				for i := 10; i > 0; i-- {
+					log.Printf("Forensics in %d", i)
+					time.Sleep(time.Second)
+				}
+				log.Printf("watchdogForensics failed: %v", err)
+			}()
+		} else {
+			go func() {
+				for i := 10; i > 0; i-- {
+					log.Printf("Forensics in %d", i)
+					time.Sleep(time.Second)
+				}
+				log.Printf("watchdogForensics:\n%s", s)
+			}()
+		}
+
 		log.Printf("SM applet verification pub:%s", PublicKey)
 
 		if err := config.Verify(taELF, taSig, PublicKey); err != nil {


### PR DESCRIPTION
Attempts to dump a forensic stack trace of the applet on OS boot. 
This is intended to help track down causes of the watchdog being triggered.