### PR TITLE
initialize key derivation memory for both P/Ns

### DIFF
--- a/trusted_os/dma.go
+++ b/trusted_os/dma.go
@@ -27,7 +27,12 @@ func init() {
 
 	dma.Init(secureDMAStart, secureDMASize)
 
-	if imx6ul.CAAM != nil {
-		imx6ul.CAAM.DeriveKeyMemory, _ = dma.NewRegion(imx6ul.OCRAM_START, imx6ul.OCRAM_SIZE, false)
+	deriveKeyMemory, _ := dma.NewRegion(imx6ul.OCRAM_START, imx6ul.OCRAM_SIZE, false)
+
+	switch {
+	case imx6ul.CAAM != nil:
+		imx6ul.CAAM.DeriveKeyMemory = deriveKeyMemory
+	case imx6ul.DCP != nil:
+		imx6ul.DCP.DeriveKeyMemory = deriveKeyMemory
 	}
 }


### PR DESCRIPTION
This ensures that key derivation can be performed on both i.MX6UL and i.MX6ULL variants.