### PR TITLE
workaround fidati pkg bug on consecutive commands

### DIFF
--- a/cmd/witnessctl/api.go
+++ b/cmd/witnessctl/api.go
@@ -95,6 +95,8 @@ func ota(taELFPath string, taSigPath string) (err error) {
 		return errors.New("trusted applet signature path must be specified (-O)")
 	}
 
+	// TODO: replace with status() after fixing
+	// https://github.com/gsora/fidati/issues/5
 	if err := detect(); err != nil {
 		return err
 	}
@@ -193,6 +195,8 @@ func cfg(dhcp bool, ip string, mask string, gw string, dns string, ntp string) e
 		NTPServer: ntp,
 	}
 
+	// TODO: replace with status() after fixing
+	// https://github.com/gsora/fidati/issues/5
 	if err := detect(); err != nil {
 		return err
 	}

--- a/cmd/witnessctl/api.go
+++ b/cmd/witnessctl/api.go
@@ -95,10 +95,8 @@ func ota(taELFPath string, taSigPath string) (err error) {
 		return errors.New("trusted applet signature path must be specified (-O)")
 	}
 
-	s, err := status()
-
-	if err != nil {
-		return
+	if err := detect(); err != nil {
+		return err
 	}
 
 	taELF, err := os.ReadFile(taELFPath)
@@ -129,7 +127,8 @@ func ota(taELFPath string, taSigPath string) (err error) {
 		return errors.New("signature size exceeds maximum update chunk size")
 	}
 
-	log.Printf("sending trusted applet signature to armored witness %s", s.Serial)
+	log.Printf("sending trusted applet signature to armored witness")
+
 	if err = sendUpdateChunk(taSig, seq, total); err != nil {
 		return
 	}
@@ -145,7 +144,7 @@ func ota(taELFPath string, taSigPath string) (err error) {
 	}(start)
 	defer bar.Finish()
 
-	log.Printf("sending trusted applet payload to armored witness %x", s.Serial)
+	log.Printf("sending trusted applet payload to armored witness")
 
 	for i := 0; i < totalSize; i += chunkSize {
 		seq += 1
@@ -198,13 +197,7 @@ func cfg(dhcp bool, ip string, mask string, gw string, dns string, ntp string) e
 		return err
 	}
 
-	s, err := status()
-
-	if err != nil {
-		return err
-	}
-
-	log.Printf("sending configuration update to armored witness %s", s.Serial)
+	log.Printf("sending configuration update to armored witness")
 
 	buf, err := conf.dev.Command(api.U2FHID_ARMORY_CFG, c.Bytes())
 


### PR DESCRIPTION
When issuing USB control commands to the api.U2FHID_ARMORY_INF mapping right before issuing one to the api.U2FHID_ARMORY_CFG mapping the following happens.


```
panic: runtime error: index out of range [2] with length 1

goroutine 33 [running]:
github.com/gsora/fidati/u2fhid.(*Handler).Tx(0x82818650, {0x0, 0x0, 0x0}, {0x0, 0x0})
        github.com/gsora/fidati@v0.0.0-20220824075547-eeb0a5f7d6c3/u2fhid/handler.go:38 +0x690
github.com/usbarmory/tamago/soc/nxp/usb.(*endpoint).tx(0x82830660)
        github.com/usbarmory/tamago@v0.0.0-20230724190245-6f2dec2f8412/soc/nxp/usb/endpoint_handler.go:44 +0x48
```

As a workaround while this issue is solved this PR avoids issuing status (which is done solely for the reason of printing out the target serial number) before CFG or OTA commands.
