### PR TITLE
set an empty derived key under emulation 

### DIFF
--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -194,6 +194,7 @@ func (r *RPC) DeriveKey(diversifier [aes.BlockSize]byte, key *[sha256.Size]byte)
 		var k []byte
 		k, err = imx6ul.DCP.DeriveKey(r.Diversifier[:], diversifier[:], -1)
 		copy(key[:], k)
+	case debug && !imx6ul.Native:
 	default:
 		err = errors.New("unsupported hardware")
 	}


### PR DESCRIPTION
This PR allows key derivation under emulation, to avoid potential security issues with emulation detection (which feels anyway [safe](https://github.com/usbarmory/tamago/blob/42b6e427753aa24d3e9138a9c8b6899692a1811e/soc/nxp/imx6ul/init.go#L67)) this is only allowed when compiled in debug mode.