### PR TITLE
Use fake storage when running on qemu in DEBUG=1 mode

### DIFF
--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/usbarmory/tamago/soc/nxp/enet"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/usb"
-	"github.com/usbarmory/tamago/soc/nxp/usdhc"
 
 	"github.com/usbarmory/armory-boot/config"
 
@@ -46,7 +45,7 @@ var (
 
 var (
 	Control *usb.USB
-	Storage *usdhc.USDHC
+	Storage Card
 
 	// USB armory Mk II (rev. β) - UA-MKII-β
 	// USB armory Mk II (rev. γ) - UA-MKII-γ
@@ -102,8 +101,6 @@ func init() {
 			Control = usbarmory.USB1
 			Control.Init()
 		}
-
-		Storage = usbarmory.MMC
 	} else {
 		LAN = imx6ul.ENET1
 		LAN.RingSize = 512
@@ -123,18 +120,16 @@ func main() {
 	usbarmory.LED("blue", false)
 	usbarmory.LED("white", false)
 
+	Storage, rpmb := storage()
 	if Storage != nil {
 		if err = Storage.Detect(); err != nil {
 			log.Fatalf("SM failed to detect storage, %v", err)
 		}
 	}
 
-	rpmb := &RPMB{
-		Storage: Storage,
-	}
-
 	rpc := &RPC{
 		RPMB:        rpmb,
+		Storage:     Storage,
 		Diversifier: sha256.Sum256([]byte(PublicKey)),
 	}
 

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -37,6 +37,7 @@ import (
 // calls.
 type RPC struct {
 	RPMB        *RPMB
+	Storage     Card
 	Ctx         *monitor.ExecCtx
 	Cfg         []byte
 	Diversifier [32]byte
@@ -120,31 +121,31 @@ func (r *RPC) LED(led rpc.LEDStatus, _ *bool) error {
 
 // CardInfo returns the storage media information.
 func (r *RPC) CardInfo(_ any, info *usdhc.CardInfo) error {
-	if r.RPMB.Storage == nil {
+	if r.Storage == nil {
 		return errors.New("missing Storage")
 	}
 
-	*info = r.RPMB.Storage.Info()
+	*info = r.Storage.Info()
 
 	return nil
 }
 
 // WriteBlocks transfers full blocks of data to the storage media.
 func (r *RPC) WriteBlocks(xfer rpc.WriteBlocks, _ *bool) error {
-	if r.RPMB.Storage == nil {
+	if r.Storage == nil {
 		return errors.New("missing Storage")
 	}
 
-	return r.RPMB.Storage.WriteBlocks(xfer.LBA, xfer.Data)
+	return r.Storage.WriteBlocks(xfer.LBA, xfer.Data)
 }
 
 // Read transfers data from the storage media.
 func (r *RPC) Read(xfer rpc.Read, out *[]byte) (err error) {
-	if r.RPMB.Storage == nil {
+	if r.Storage == nil {
 		return errors.New("missing Storage")
 	}
 
-	*out, err = r.RPMB.Storage.Read(xfer.Offset, xfer.Size)
+	*out, err = r.Storage.Read(xfer.Offset, xfer.Size)
 
 	return
 }

--- a/trusted_os/rpmb.go
+++ b/trusted_os/rpmb.go
@@ -55,7 +55,7 @@ const (
 )
 
 type RPMB struct {
-	Storage   *usdhc.USDHC
+	storage   *usdhc.USDHC
 	partition *rpmb.RPMB
 }
 
@@ -80,7 +80,7 @@ func (r *RPMB) init() (err error) {
 
 	// setup RPMB partition
 	r.partition, err = rpmb.Init(
-		r.Storage,
+		r.storage,
 		pbkdf2.Key(dk, uid[:], iter, sha256.Size, sha256.New),
 		dummySector,
 	)

--- a/trusted_os/storage.go
+++ b/trusted_os/storage.go
@@ -1,0 +1,27 @@
+// Copyright 2023 The Armored Witness OS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !debug
+// +build !debug
+
+package main
+
+import (
+	usbarmory "github.com/usbarmory/tamago/board/usbarmory/mk2"
+)
+
+func storage() (Card, *RPMB) {
+	s := usbarmory.MMC
+	return s, &RPMB{storage: s}
+}

--- a/trusted_os/storage_debug.go
+++ b/trusted_os/storage_debug.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"log"
 
+	usbarmory "github.com/usbarmory/tamago/board/usbarmory/mk2"
+	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
 	"github.com/usbarmory/tamago/soc/nxp/usdhc"
 )
 
@@ -31,7 +33,13 @@ const (
 	fakeCardNumBlocks = int64(4<<30) / fakeCardBlockSize
 )
 
+// storage will return MMC backed storage if running on real hardware, or
+// a fake in-memory storage device otherwise.
 func storage() (Card, *RPMB) {
+	if imx6ul.Native {
+		s := usbarmory.MMC
+		return s, &RPMB{storage: s}
+	}
 	return newFakeCard(fakeCardNumBlocks), &RPMB{}
 }
 

--- a/trusted_os/storage_debug.go
+++ b/trusted_os/storage_debug.go
@@ -1,0 +1,103 @@
+// Copyright 2023 The Armored Witness OS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build debug
+// +build debug
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/usbarmory/tamago/soc/nxp/usdhc"
+)
+
+const (
+	// fakeCardBlockSize is the number of bytes in a single memory block.
+	fakeCardBlockSize = int64(512)
+	// fakeCardNumBlocks defines the claimed size of the storage.
+	fakeCardNumBlocks = int64(4<<30) / fakeCardBlockSize
+)
+
+func storage() (Card, *RPMB) {
+	return newFakeCard(fakeCardNumBlocks), &RPMB{}
+}
+
+// fakeCard is an implementation of an in-memory storage device.
+//
+// Rather than allocating a slab of RAM to emulate the entire device, it
+// uses a map internally to associate slices (<= fakeCardBlockSize bytes)
+// with sector numbers - this allows us to save RAM on unused/unwritten blocks.
+type fakeCard struct {
+	info usdhc.CardInfo
+	mem  map[int64][]byte
+}
+
+// Read returns size bytes at offset in the fake storage
+func (fc *fakeCard) Read(offset int64, size int64) ([]byte, error) {
+	l := int64(fakeCardNumBlocks * fakeCardBlockSize)
+	if offset >= l {
+		return nil, fmt.Errorf("offset (%d) past end of storage (%d)", offset, l)
+	}
+	if offset+size > l {
+		size = l - offset
+	}
+	if offset%fakeCardBlockSize != 0 {
+		panic(fmt.Sprintf("non sector-aligned read at %d", offset))
+	}
+	r := make([]byte, size)
+	base := offset / fakeCardBlockSize
+	for i, rem := int64(0), size; rem > 0; i, rem = i+1, rem-fakeCardBlockSize {
+		copy(r[i*fakeCardBlockSize:], fc.mem[base+i])
+	}
+	return r, nil
+}
+
+func (fc *fakeCard) WriteBlocks(lba int, b []byte) error {
+	if l := fakeCardNumBlocks; int64(lba) >= l {
+		return fmt.Errorf("lba (%d) >= device blocks (%d)", lba, l)
+	}
+	// If the data isn't a multiple of the blocksize, pad it up
+	// so that it is.
+	if r := int64(len(b)) % fakeCardBlockSize; r != 0 {
+		b = append(b, make([]byte, fakeCardBlockSize-r)...)
+	}
+	for i, rem := int64(0), int64(len(b)); rem > 0; i, rem = i+1, rem-fakeCardBlockSize {
+		buf := make([]byte, fakeCardBlockSize)
+		copy(buf, b[i*fakeCardBlockSize:])
+		fc.mem[int64(lba)+i] = buf
+	}
+	return nil
+}
+
+func (fc *fakeCard) Info() usdhc.CardInfo {
+	return fc.info
+}
+
+func (fc *fakeCard) Detect() error {
+	log.Println("Using fake MMC storage")
+	return nil
+}
+
+// newFakeCard creates a new in-memory block device.
+func newFakeCard(numBlocks int64) *fakeCard {
+	return &fakeCard{
+		mem: make(map[int64][]byte),
+		info: usdhc.CardInfo{
+			BlockSize: int(fakeCardBlockSize),
+			Blocks:    int(numBlocks),
+		},
+	}
+}


### PR DESCRIPTION
This change causes `DEBUG=1` OS builds to compile-in a "fake" RAM-based storage which is used in place of MMC flash when not running on native h/w. Since this happens as the OS level, it's completely transparent to the applet.

This allows us to run the OS+applet under `qemu` (which has no emulation of the MMC device) without needing to manually modify storage code _in the applet_, making debugging easier.