### PR TITLE
Add Update related RPC stubs

### DIFF
--- a/api/rpc/rpc.go
+++ b/api/rpc/rpc.go
@@ -14,6 +14,11 @@
 
 package rpc
 
+import (
+	"github.com/coreos/go-semver/semver"
+	"github.com/transparency-dev/armored-witness-boot/config"
+)
+
 // Handler represents an RPC request for event handler registration.
 type Handler struct {
 	G uint32
@@ -44,4 +49,17 @@ type WitnessStatus struct {
 	Identity string
 	// IP is the currently-assigned IP address of the witness applet.
 	IP string
+}
+
+// FirmwareUpdate represnts a firmware update
+type FirmwareUpdate struct {
+	Image []byte
+	Proof config.ProofBundle
+}
+
+// InstalledVersions represents the installed/running versions
+// of the TrustedOS and applet.
+type InstalledVersions struct {
+	OS     semver.Version
+	Applet semver.Version
 }

--- a/api/rpc/rpc.go
+++ b/api/rpc/rpc.go
@@ -51,9 +51,11 @@ type WitnessStatus struct {
 	IP string
 }
 
-// FirmwareUpdate represnts a firmware update
+// FirmwareUpdate represents a firmware update
 type FirmwareUpdate struct {
+	// Image is the firmware image to be applied.
 	Image []byte
+	//  Proof contains firmware transparency artefacts for the new firmware image.
 	Proof config.ProofBundle
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.19
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.0
+	github.com/coreos/go-semver v0.3.1
 	github.com/flynn/hid v0.0.0-20190502022136-f1b9b6cc019a
 	github.com/flynn/u2f v0.0.0-20180613185708-15554eb68e5d
 	github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3
-	github.com/transparency-dev/armored-witness-boot v0.0.0-20230503134353-2eb910e5f86f
+	github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7
 	github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4
 	github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d
 	github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e
@@ -31,9 +32,10 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
-	github.com/u-root/u-root v7.0.0+incompatible // indirect
+	github.com/u-root/u-root v0.11.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
 github.com/cheggaaa/pb/v3 v3.1.0/go.mod h1:YjrevcBqadFDaGQKRdmZxTY42pXEqda48Ea3lt0K/BE=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -47,6 +49,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/pierrec/lz4/v4 v4.1.14 h1:+fL8AQEZtz/ijeNnpduH0bROTu0O3NZAlPjQxGn8LwE=
+github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -63,10 +67,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/transparency-dev/armored-witness-boot v0.0.0-20230503134353-2eb910e5f86f h1:Erl2lxIWPBShxTtoxp5wxhvzj99U5lS7aMTTsDL7Sog=
-github.com/transparency-dev/armored-witness-boot v0.0.0-20230503134353-2eb910e5f86f/go.mod h1:dOVSbiLcksM6B6KedbBOLJIPpnCY5jdxzdC3Rdi6lGA=
-github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
-github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
+github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7 h1:3xrmiN4hwWi3nxvDo9asUWrNCjaPYBhF+rHpW97Fde0=
+github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
+github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
+github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
 github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4 h1:fdcx7wzwuQkyo0hR32eJQsW9eb3FAcU874zd1Ji8juM=
 github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4/go.mod h1:164CE5Gb+PiM6cxhYpyPg9FlpqttRFwUZ+KiTonK4Ak=
 github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d h1:oIdJllwCnP/ZPfdrB5fB+zH3+NM+EFW8lCNiRhVKw1s=

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -215,6 +215,24 @@ func (r *RPC) HAB(srk []byte, _ *bool) error {
 	return hab.Activate(srk)
 }
 
+// GetInstalledVersions returns the semantic versions of the OS and Applet
+// installed on this device. These will be the same versions that are
+// currently running.
+func (r *RPC) GetInstalledVersions(_ *any, v *rpc.InstalledVersions) error {
+	return errors.New("unimplemented")
+}
+
+// InstallOS updates the OS to the version contained in the firmware bundle.
+func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
+	return errors.New("unimplemented")
+
+}
+
+// InstallApplet updates the Applet to the version contained in the firmware bundle.
+func (r *RPC) InstallApplet(b *rpc.FirmwareUpdate, _ *bool) error {
+	return errors.New("unimplemented")
+}
+
 // Reboot resets the system.
 func (r *RPC) Reboot(_ *any, _ *bool) error {
 	log.Printf("SM rebooting")

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -223,12 +223,16 @@ func (r *RPC) GetInstalledVersions(_ *any, v *rpc.InstalledVersions) error {
 }
 
 // InstallOS updates the OS to the version contained in the firmware bundle.
+// If the update is successful, this func will not return and the device will
+// immediately reboot.
 func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
 	return errors.New("unimplemented")
 
 }
 
 // InstallApplet updates the Applet to the version contained in the firmware bundle.
+// If the update is successful, this func will not return and the device will
+// immediately reboot.
 func (r *RPC) InstallApplet(b *rpc.FirmwareUpdate, _ *bool) error {
 	return errors.New("unimplemented")
 }


### PR DESCRIPTION
Adds the outline of an RPC implementation of the applet's `UpdateLocal` interface.



