### PR TITLE
Keep symbols on qemu-gdb target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,10 +171,12 @@ dcd:
 clean:
 	@rm -fr $(CURDIR)/bin/* $(CURDIR)/trusted_os/assets/* $(CURDIR)/qemu.dtb
 
-qemu:
+qemu: trusted_os_embedded_applet_signed
 	$(QEMU) -kernel $(CURDIR)/bin/trusted_os.elf
 
-qemu-gdb:
+qemu-gdb: GOFLAGS := $(GOFLAGS:-w=)
+qemu-gdb: GOFLAGS := $(GOFLAGS:-s=)
+qemu-gdb: trusted_os_embedded_applet_signed
 	$(QEMU) -kernel $(CURDIR)/bin/trusted_os.elf -S -s
 
 #### application target ####

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ support (requires a `tap0` device routing the Trusted Applet IP address).
 > support by QEMU.
 
 ```
-make DEBUG=1 trusted_os && make qemu
+make DEBUG=1 make qemu
 ...
 00:00:00 tamago/arm • TEE security monitor (Secure World system/monitor)
 00:00:00 SM applet verification


### PR DESCRIPTION
This PR ensures that debugging symbols are kept on the ELF compiled for qemu + GDB execution.