### PR TITLE
Add support for firmware logging

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.20.7
+      TAMAGO_VERSION: 1.21.0
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ BUILD_EPOCH := $(shell /bin/date -u "+%s")
 BUILD_TAGS = linkramsize,linkramstart,disable_fr_auth,linkprintk
 BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
+DEV_LOG_DIR ?= ./bin/log
+DEV_LOG_ORIGIN ?= "DEV.armoredwitness.transparency.dev/${USER}"
+GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0-'`git rev-parse HEAD`) | tail -c +2 )
 
 PROTOC ?= /usr/bin/protoc
 
@@ -56,13 +59,11 @@ GOFLAGS = -tags ${BUILD_TAGS} -trimpath -ldflags "-s -w -T ${TEXT_START} -E ${EN
 
 all: trusted_os_embedded_applet_signed witnessctl
 
-elf: $(APP).elf
-
 # This target is only used for dev builds, since the proto definitions may
 # change in development and require re-compilation of protos.
 trusted_os: APP=trusted_os
 trusted_os: DIR=$(CURDIR)/trusted_os
-trusted_os: create_dummy_applet proto elf
+trusted_os: create_dummy_applet proto elf manifest
 
 trusted_os_signed: trusted_os
 	echo "signing Trusted OS"
@@ -76,7 +77,7 @@ trusted_os_signed: trusted_os
 
 trusted_os_embedded_applet_signed: APP=trusted_os
 trusted_os_embedded_applet_signed: DIR=$(CURDIR)/trusted_os
-trusted_os_embedded_applet_signed: check_os_env copy_applet proto elf imx
+trusted_os_embedded_applet_signed: check_os_env copy_applet proto elf manifest imx
 trusted_os_embedded_applet_signed:
 	echo "signing Trusted OS"
 	@if [ "${SIGN_PWD}" != "" ]; then \
@@ -97,11 +98,46 @@ witnessctl: check_tamago
 # used by the GCP build process and signed there.
 trusted_os_release: APP=trusted_os
 trusted_os_release: DIR=$(CURDIR)/trusted_os
-trusted_os_release: create_dummy_applet elf
+trusted_os_release: create_dummy_applet elf manifest
+
+## Targets for managing a local serverless log instance for dev/testing FT related bits.
+
+## log_initialise initialises the log stored at the path in DEV_LOG_DIR.
+## If the log already exists, it will be reset.
+log_initialise:
+	echo "(Re-)initialising log at ${DEV_LOG_DIR}"
+	@rm -fr ${DEV_LOG_DIR}
+	go run github.com/transparency-dev/serverless-log/cmd/integrate@a56a93b5681e5dc231882ac9de435c21cb340846 \
+		--storage_dir=${DEV_LOG_DIR} \
+		--origin=${DEV_LOG_ORIGIN} \
+		--public_key=${LOG_PUBLIC_KEY} \
+		--initialise
+
+## log_os adds the trusted_os_manifest.json file created during the build to the dev FT log.
+log_os:
+	@if [ "${LOG_PRIVATE_KEY}" == "" -o "${LOG_PUBLIC_KEY}" == "" ]; then \
+		@echo "You need to set LOG_PRIVATE_KEY and LOG_PUBLIC_KEY variables"; \
+		exit 1; \
+	fi
+	@if [ ! -f ${DEV_LOG_DIR}/checkpoint ]; then \
+		make log_initialise; \
+	fi
+	go run github.com/transparency-dev/serverless-log/cmd/sequence@a56a93b5681e5dc231882ac9de435c21cb340846 \
+		--storage_dir=${DEV_LOG_DIR} \
+		--origin=${DEV_LOG_ORIGIN} \
+		--public_key=${LOG_PUBLIC_KEY} \
+		--entries=${CURDIR}/bin/trusted_os_manifest.json
+	-go run github.com/transparency-dev/serverless-log/cmd/integrate@a56a93b5681e5dc231882ac9de435c21cb340846 \
+		--storage_dir=${DEV_LOG_DIR} \
+		--origin=${DEV_LOG_ORIGIN} \
+		--private_key=${LOG_PRIVATE_KEY} \
+		--public_key=${LOG_PUBLIC_KEY}
 
 #### ARM targets ####
 
 imx: $(APP).imx
+elf: $(APP).elf
+manifest: $(APP)_manifest.json
 
 proto:
 	@echo "generating protobuf classes"
@@ -183,3 +219,16 @@ qemu-gdb: trusted_os_embedded_applet_signed
 
 $(APP).elf: check_tamago
 	cd $(DIR) && $(GOENV) $(TAMAGO) build -tags ${BUILD_TAGS} $(GOFLAGS) -o $(CURDIR)/bin/$(APP).elf
+
+$(APP)_manifest.json: TAMAGO_SEMVER=$(shell ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
+$(APP)_manifest.json:
+	# Create manifest
+	go run github.com/transparency-dev/armored-witness/cmd/manifest@e852dd82d9d56121576aff66de89e800380e5d53 \
+		--git_tag=${GIT_SEMVER_TAG} \
+		--git_commit_fingerprint="${REV}" \
+		--firmware_file=${CURDIR}/bin/$(APP).elf \
+		--firmware_type=TRUSTED_OS \
+		--tamago_version=${TAMAGO_SEMVER} > ${CURDIR}/bin/${APP}_manifest.json
+	@echo ---------- Manifest --------------
+	@cat ${CURDIR}/bin/${APP}_manifest.json
+	@echo ----------------------------------

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 DEV_LOG_DIR ?= ./bin/log
 DEV_LOG_ORIGIN ?= "DEV.armoredwitness.transparency.dev/${USER}"
-GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0-'`git rev-parse HEAD`) | tail -c +2 )
+GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n 'v0.0.0+'`git rev-parse HEAD`) | tail -c +2 )
 
 PROTOC ?= /usr/bin/protoc
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e
 	github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e
 	github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8
-	github.com/usbarmory/tamago v0.0.0-20230829132607-64264ab65702
+	github.com/usbarmory/tamago v0.0.0-20230913163007-a90ba4e21ad6
 	golang.org/x/crypto v0.8.0
 	google.golang.org/protobuf v1.30.0
 	gvisor.dev/gvisor v0.0.0-20230614190805-57027c7d31f8

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/flynn/u2f v0.0.0-20180613185708-15554eb68e5d
 	github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3
 	github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7
-	github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4
+	github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9
 	github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d
 	github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e
 	github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e
 	github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8
-	github.com/usbarmory/tamago v0.0.0-20230913163007-a90ba4e21ad6
+	github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe
 	golang.org/x/crypto v0.8.0
 	google.golang.org/protobuf v1.30.0
 	gvisor.dev/gvisor v0.0.0-20230614190805-57027c7d31f8

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c766
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
 github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
 github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
+github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9 h1:bVjcARGT+mwll/+no7bsCCC1UDldtuNXL00twGtLPGo=
+github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9/go.mod h1:mPJL62h2iMZwmu2cZ/tvjCyk0uSeq06n1UJBoigN2qY=
 github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d h1:oIdJllwCnP/ZPfdrB5fB+zH3+NM+EFW8lCNiRhVKw1s=
 github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d/go.mod h1:2+FV8fn4y14BkPvrUdZ35mxQuMb1JcDxOZy6lFvHzj8=
 github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e h1:6hKgQCr5x22jR8SLQ9W6+X2YitRqBAmfCSuIqYskh4c=
@@ -79,6 +81,9 @@ github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e h1:x2vSKye5+6
 github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e/go.mod h1:eT+4LgXX1S+pyzpTtg0P5vCqvzQA4/kA1b/kmiMqQbE=
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8 h1:VPruqXJEJxTweSRyx3NIkiIqQl9ppZHp4wZnL8+Y0aI=
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8/go.mod h1:XfTrYj8Ik3ljit1cSHTcsXs7lyJ/QMsplPDX8+g5s7c=
+github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
+github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe h1:h3PrTFE6iPJzyYz+/2iyIPCUS5yyuqPHRCMsW2IXk3k=
+github.com/usbarmory/tamago v0.0.0-20230922151120-1f76695abebe/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c766
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
 github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
 github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
-github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4 h1:fdcx7wzwuQkyo0hR32eJQsW9eb3FAcU874zd1Ji8juM=
-github.com/usbarmory/GoTEE v0.0.0-20230828134615-ef53a1a84ba4/go.mod h1:164CE5Gb+PiM6cxhYpyPg9FlpqttRFwUZ+KiTonK4Ak=
 github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d h1:oIdJllwCnP/ZPfdrB5fB+zH3+NM+EFW8lCNiRhVKw1s=
 github.com/usbarmory/armory-boot v0.0.0-20230724181259-b0947883370d/go.mod h1:2+FV8fn4y14BkPvrUdZ35mxQuMb1JcDxOZy6lFvHzj8=
 github.com/usbarmory/crucible v0.0.0-20230412092556-269c90b0067e h1:6hKgQCr5x22jR8SLQ9W6+X2YitRqBAmfCSuIqYskh4c=
@@ -81,9 +79,6 @@ github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e h1:x2vSKye5+6
 github.com/usbarmory/imx-usbnet v0.0.0-20230626092818-ef791923688e/go.mod h1:eT+4LgXX1S+pyzpTtg0P5vCqvzQA4/kA1b/kmiMqQbE=
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8 h1:VPruqXJEJxTweSRyx3NIkiIqQl9ppZHp4wZnL8+Y0aI=
 github.com/usbarmory/imx-usbserial v0.0.0-20230503192150-40b6298b31f8/go.mod h1:XfTrYj8Ik3ljit1cSHTcsXs7lyJ/QMsplPDX8+g5s7c=
-github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
-github.com/usbarmory/tamago v0.0.0-20230829132607-64264ab65702 h1:6ZCdT389pu9VKNyZoSBkJ0qvUESNHXuR5fnrKIczTUM=
-github.com/usbarmory/tamago v0.0.0-20230829132607-64264ab65702/go.mod h1:uCPXcPo8SZulhZPz8irfVqzwVlPZ45w7CTJxkfxueGA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=


### PR DESCRIPTION
Adds support for logging firmware artefacts to a local FT log for development purposes.
Analogous to transparency-dev/armored-witness-applet/pull/114 .

Needs transparency-dev/armored-witness/pull/17 .