### PR TITLE
Remove protoc from Dockerfile and update installed dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
-FROM amd64/golang:latest
+FROM golang:1.21-bookworm
 
 ARG TAMAGO_VERSION
 
 # Install dependencies.
-RUN apt-get update && apt-get install -y make
-RUN apt-get install -y unzip
-RUN apt-get install -y wget
-RUN apt-get install -y u-boot-tools
-RUN apt-get install -y binutils-arm-none-eabi
-
-RUN go install "google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOC_GEN_GO_VERSION}"
-
-RUN wget "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
-RUN unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /
-# Set protoc path for Make rule.
-ENV PROTOC=/bin/protoc
+RUN apt-get update && apt-get install -y make wget u-boot-tools binutils-arm-none-eabi
 
 RUN wget "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
 RUN tar -xvf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /


### PR DESCRIPTION
We do not need protoc anymore after https://github.com/transparency-dev/armored-witness-os/pull/56