### PR TITLE
Sign manifest for local dev

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -29,13 +29,9 @@ jobs:
         echo "${HOME}/go/bin" >> $GITHUB_PATH
     - name: Create throwaway keys & fake embed
       run: |
-        signify-openbsd -G -n -p ${APPLET_PUBLIC_KEY} -s ${APPLET_PRIVATE_KEY}
-        signify-openbsd -G -n -p ${OS_PUBLIC_KEY1} -s ${OS_PRIVATE_KEY1}
-        signify-openbsd -G -n -p ${OS_PUBLIC_KEY2} -s ${OS_PRIVATE_KEY2}
-        # Now create a fake applet to embed, and sign it
-        mkdir -p ${APPLET_PATH}
-        echo "When I grow up, I want to be an applet" > ${APPLET_PATH}/trusted_applet.elf
-        signify-openbsd -S -s ${APPLET_PRIVATE_KEY} -m ${APPLET_PATH}/trusted_applet.elf -x ${APPLET_PATH}/trusted_applet.sig
+        go run github.com/transparency-dev/serverless-log/cmd/generate_keys@14ed652b57527bb17e065e921eb0fcce3cbc8a49 --key_name="TEST-APPLET" --out_priv=${APPLET_PRIVATE_KEY} --out_pub=${APPLET_PUBLIC_KEY}
+        go run github.com/transparency-dev/serverless-log/cmd/generate_keys@14ed652b57527bb17e065e921eb0fcce3cbc8a49 --key_name="TEST-OS-1" --out_priv=${OS_PRIVATE_KEY1} --out_pub=${OS_PUBLIC_KEY1}
+        go run github.com/transparency-dev/serverless-log/cmd/generate_keys@14ed652b57527bb17e065e921eb0fcce3cbc8a49 --key_name="TEST-OS-2" --out_priv=${OS_PRIVATE_KEY2} --out_pub=${OS_PUBLIC_KEY2}
     - name: Make
       run: |
         DEBUG=1 make trusted_os

--- a/Makefile
+++ b/Makefile
@@ -242,3 +242,12 @@ $(APP)_manifest:
 		--private_key_file=${OS_PRIVATE_KEY1} \
 		--output_file=${CURDIR}/bin/${APP}_manifest
 	@echo ----------------------------------
+	# Now counter sign with OS_PRIVATE_KEY2
+	go run github.com/transparency-dev/armored-witness/cmd/manifest@228f2f6432babe1f1657e150ce0ca4a96ab394da \
+		create \
+		--git_tag=${GIT_SEMVER_TAG} \
+		--git_commit_fingerprint="${REV}" \
+		--firmware_file=${CURDIR}/bin/$(APP).elf \
+		--firmware_type=TRUSTED_OS \
+		--tamago_version=${TAMAGO_SEMVER} \
+		--private_key_file=${OS_PRIVATE_KEY2} | tail -1 >> ${CURDIR}/bin/${APP}_manifest


### PR DESCRIPTION
This PR enables local dev support for signed manifests.

To fit with the two-party scheme we'd already planned for the ELF signatures, this change will cause the manifest file to be signed with both local keys.