### PR TITLE
Improve update RPC flow

### DIFF
--- a/api/rpc/rpc.go
+++ b/api/rpc/rpc.go
@@ -56,9 +56,6 @@ type FirmwareUpdate struct {
 	// Image is the firmware image to be applied.
 	Image []byte
 
-	// Signatures contains authentication signatures for the firmware.
-	Signatures [][]byte
-
 	//  Proof contains firmware transparency artefacts for the new firmware image.
 	Proof config.ProofBundle
 }

--- a/cmd/proofbundle/main.go
+++ b/cmd/proofbundle/main.go
@@ -96,7 +96,7 @@ func main() {
 		LogVerifer:        logVerifier,
 		ManifestVerifiers: []note.Verifier{mv},
 	}
-	if err := v.Verify(bundle); err != nil {
+	if _, err := v.Verify(bundle); err != nil {
 		klog.Exitf("Failed to verify proof bundle: %v", err)
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b h1:d8bLTgqLrvH1VJyNUTAzLyY/Ux13s7QHb19vEcTum7E=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7 h1:3xrmiN4hwWi3nxvDo9asUWrNCjaPYBhF+rHpW97Fde0=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231012085018-f5e62744cd3e h1:xfRW77mjLPStON23m0cRHtkMhy/Hyc9LefW/MhFCZ2s=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231012085018-f5e62744cd3e/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b h1:d8bLTgqLrvH1VJyNUTAzLyY/Ux13s7QHb19vEcTum7E=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7 h1:3xrmiN4hwWi3nxvDo9asUWrNCjaPYBhF+rHpW97Fde0=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231012085018-f5e62744cd3e h1:xfRW77mjLPStON23m0cRHtkMhy/Hyc9LefW/MhFCZ2s=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231012085018-f5e62744cd3e/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -183,8 +183,20 @@ func blinkenLights() (func(), func()) {
 }
 
 // updateApplet verifies an applet update and flashes it to internal storage
-func updateApplet(taELF []byte, pb config.ProofBundle) (err error) {
-	// TODO: OS applet verification
+func updateApplet(storage Card, taELF []byte, pb config.ProofBundle) (err error) {
+	// First, verify everything is correct and that, as far as we can tell,
+	// we would succeed in loadering and launching this applet upon next boot.
+	bundle := firmware.Bundle{
+		Checkpoint:     pb.Checkpoint,
+		Index:          pb.LogIndex,
+		InclusionProof: pb.InclusionProof,
+		Manifest:       pb.Manifest,
+		Firmware:       taELF,
+	}
+	if _, err := AppletBundleVerifier.Verify(bundle); err != nil {
+		return err
+	}
+	log.Printf("SM verified applet bundle for update")
 
 	return flashFirmware(storage, Firmware_Applet, taELF, pb)
 }

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -203,7 +203,7 @@ func updateApplet(storage Card, taELF []byte, pb config.ProofBundle) (err error)
 
 // updateOS verifies an OS update and flashes it to internal storage
 func updateOS(storage Card, osELF []byte, pb config.ProofBundle) (err error) {
-	// TODO: OS signature verification
+	// TODO: OS proof bundle verification
 
 	return flashFirmware(storage, Firmware_OS, osELF, pb)
 }

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -126,10 +126,6 @@ func flash(card Card, buf []byte, lba int) (err error) {
 		return fmt.Errorf("h/w invariant error - expected MMC blocksize %d, found %d", expectedBlockSize, blockSize)
 	}
 
-	if blockSize == 0 {
-		return errors.New("invalid block size")
-	}
-
 	if rem := len(buf) % blockSize; rem > 0 {
 		buf = append(buf, make([]byte, blockSize-rem)...)
 	}

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -195,7 +195,7 @@ func main() {
 	}
 
 	if ta != nil {
-		_, err := AppletBundleVerifier.Verify(*ta)
+		manifest, err := AppletBundleVerifier.Verify(*ta)
 		if err != nil {
 			log.Printf("SM applet verification error, %v", err)
 		}

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -49,7 +49,6 @@ var (
 
 var (
 	Control *usb.USB
-	Storage Card
 
 	// USB armory Mk II (rev. β) - UA-MKII-β
 	// USB armory Mk II (rev. γ) - UA-MKII-γ

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -62,6 +62,8 @@ var (
 	// loadedAppletVersion is taken from the manifest used to verify the
 	// applet.
 	loadedAppletVersion semver.Version
+
+	AppletBundleVerifier firmware.BundleVerifier
 )
 
 // A Trusted Applet can be embedded for testing purposes with QEMU.
@@ -165,6 +167,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("SM invalid AppletlManifestogVerifier: %v", err)
 	}
+	AppletBundleVerifier = firmware.BundleVerifier{
+		LogOrigin:         AppletLogOrigin,
+		LogVerifer:        logVerifier,
+		ManifestVerifiers: []note.Verifier{appletVerifier},
+	}
 
 	if v, err := semver.NewVersion(Version); err != nil {
 		log.Printf("Failed to parse OS version %q: %v", Version, err)
@@ -188,13 +195,7 @@ func main() {
 	}
 
 	if ta != nil {
-		bv := firmware.BundleVerifier{
-			LogOrigin:         AppletLogOrigin,
-			LogVerifer:        logVerifier,
-			ManifestVerifiers: []note.Verifier{appletVerifier},
-		}
-
-		manifest, err := bv.Verify(*ta)
+		_, err := AppletBundleVerifier.Verify(*ta)
 		if err != nil {
 			log.Printf("SM applet verification error, %v", err)
 		}

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -230,7 +230,7 @@ func (r *RPC) GetInstalledVersions(_ *any, v *rpc.InstalledVersions) error {
 // If the update is successful, this func will not return and the device will
 // immediately reboot.
 func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
-	if err := updateOS(b.Image, b.Proof); err != nil {
+	if err := updateOS(r.Storage, b.Image, b.Proof); err != nil {
 		return err
 	}
 	r.Ctx.Stop()
@@ -243,7 +243,7 @@ func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
 // If the update is successful, this func will not return and the device will
 // immediately reboot.
 func (r *RPC) InstallApplet(b *rpc.FirmwareUpdate, _ *bool) error {
-	if err := updateApplet(b.Image, b.Proof); err != nil {
+	if err := updateApplet(r.Storage, b.Image, b.Proof); err != nil {
 		return err
 	}
 	r.Ctx.Stop()
@@ -255,6 +255,8 @@ func (r *RPC) InstallApplet(b *rpc.FirmwareUpdate, _ *bool) error {
 // Reboot resets the system.
 func (r *RPC) Reboot(_ *any, _ *bool) error {
 	log.Printf("SM rebooting")
+	// Reduce Watchdog timeout for a faster reboot:
+	imx6ul.WDOG2.Service(500)
 	usbarmory.Reset()
 
 	return nil

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -230,7 +230,7 @@ func (r *RPC) GetInstalledVersions(_ *any, v *rpc.InstalledVersions) error {
 // If the update is successful, this func will not return and the device will
 // immediately reboot.
 func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
-	if err := updateOS(b.Image, b.Signatures, b.Proof); err != nil {
+	if err := updateOS(b.Image, b.Proof); err != nil {
 		return err
 	}
 	r.Ctx.Stop()
@@ -243,11 +243,7 @@ func (r *RPC) InstallOS(b *rpc.FirmwareUpdate, _ *bool) error {
 // If the update is successful, this func will not return and the device will
 // immediately reboot.
 func (r *RPC) InstallApplet(b *rpc.FirmwareUpdate, _ *bool) error {
-	if len(b.Signatures) == 0 {
-		return errors.New("missing signature")
-	}
-
-	if err := updateApplet(b.Image, b.Signatures[0], b.Proof); err != nil {
+	if err := updateApplet(b.Image, b.Proof); err != nil {
 		return err
 	}
 	r.Ctx.Stop()


### PR DESCRIPTION
This PR improves the update flow and fixes some issues:
- Remove all trace of detected signatures as we're now relying on manifest signatures
- Pad short buffers being written to MMC so the last sector will always be written
- Verify the proof bundle for the applet before writing to MMC