### PR TITLE
Store OS firmware binary in CAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ log_initialise:
 
 ## log_os adds the trusted_os_manifest file created during the build to the dev FT log.
 log_os: LOG_STORAGE_DIR=$(DEV_LOG_DIR)/log
-log_os: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)/trusted-os/$(GIT_SEMVER_TAG)
+log_os: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)
+log_os: ARTEFACT_HASH=$(shell sha256sum ${CURDIR}/bin/trusted_os.elf | cut -f1 -d" ")
 log_os:
 	@if [ "${LOG_PRIVATE_KEY}" == "" -o "${LOG_PUBLIC_KEY}" == "" ]; then \
 		@echo "You need to set LOG_PRIVATE_KEY and LOG_PUBLIC_KEY variables"; \
@@ -124,7 +125,7 @@ log_os:
 		--private_key=${LOG_PRIVATE_KEY} \
 		--public_key=${LOG_PUBLIC_KEY}
 	@mkdir -p ${LOG_ARTEFACT_DIR}
-	cp ${CURDIR}/bin/trusted_os.* ${LOG_ARTEFACT_DIR}
+	cp ${CURDIR}/bin/trusted_os.elf ${LOG_ARTEFACT_DIR}/${ARTEFACT_HASH}
 
 
 #### ARM targets ####

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ log_initialise:
 
 ## log_os adds the trusted_os_manifest file created during the build to the dev FT log.
 log_os: LOG_STORAGE_DIR=$(DEV_LOG_DIR)/log
-log_os: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)
+log_os: LOG_ARTEFACT_DIR=$(DEV_LOG_DIR)/artefacts
 log_os: ARTEFACT_HASH=$(shell sha256sum ${CURDIR}/bin/trusted_os.elf | cut -f1 -d" ")
 log_os:
 	@if [ "${LOG_PRIVATE_KEY}" == "" -o "${LOG_PUBLIC_KEY}" == "" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/flynn/u2f v0.0.0-20180613185708-15554eb68e5d
 	github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3
 	github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7
-	github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d
+	github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27
 	github.com/transparency-dev/merkle v0.0.2
 	github.com/transparency-dev/serverless-log v0.0.0-20230922115421-a56a93b5681e
 	github.com/usbarmory/GoTEE v0.0.0-20230914094934-f4f769daa5a9

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b h1:d8bLTgqLrvH1VJyNUTAzLyY/Ux13s7QHb19vEcTum7E=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7 h1:3xrmiN4hwWi3nxvDo9asUWrNCjaPYBhF+rHpW97Fde0=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c766
 github.com/transparency-dev/armored-witness-boot v0.0.0-20230904140406-e2e16c7665b7/go.mod h1:GTj2zM9nwFe7G7gaXzIbkKJ/PkZfvVq4TdNiA6CBsdo=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813/go.mod h1:J2NdDb6IhKIvF6MwCvKikz9/QStRylEtS2mv+En+jBg=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -57,6 +57,7 @@ steps:
       - --raw
       - --output_file=output/trusted_os_manifest_unsigned.json
   # Sign the log entry.
+  # TODO: sign the manifest twice to mimic the WithSecure 2nd signature flow.
   - name: golang
     args:
       - go
@@ -68,10 +69,8 @@ steps:
       - run
       - github.com/transparency-dev/armored-witness/cmd/sign
       - --project_name=${PROJECT_ID}
-      - --key_ring=${_KMS_KEYRING}
-      - --key_name=${_KMS_KEY}
-      - --key_version=${_KMS_KEY_VERSION}
-      - --key_location=${_REGION}
+      - --release="ci"
+      - --artefact="os1"
       - --manifest_file=output/trusted_os_manifest_unsigned.json
       - --output_file=output/trusted_os_manifest_transparency_dev
   # Print the content of the signed manifest.
@@ -92,8 +91,3 @@ substitutions:
   _FIRMWARE_COMPONENT: trusted-os
   _TAMAGO_VERSION: '1.20.6'
   _TEST_TAG_NAME: '0.1.2'
-  # Signing-related.
-  _REGION: global
-  _KMS_KEY: trusted-os-1-ci
-  _KMS_KEYRING: firmware-release-ci
-  _KMS_KEY_VERSION: '1'

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -30,11 +30,13 @@ steps:
       - output
   # Copy the artifacts from the Cloud Build VM to GCS.
   - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
     args:
+      - gcloud
       - storage
       - cp
       - output/trusted_os.elf
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_os.elf
+      - gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_os.elf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   - name: golang
     args:

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -78,16 +78,37 @@ steps:
     args:
       - cat
       - output/trusted_os_manifest_transparency_dev
-  # Copy manifest JSON to the release bucket so that WithSecure may read it.
+  ### Write the firmware release to the CI transparency log.
+  # Copy the signed note to the sequence bucket, preparing to write to log.
   - name: gcr.io/cloud-builders/gcloud
     args:
       - storage
       - cp
       - output/trusted_os_manifest_transparency_dev
-      - gs://${_FIRMWARE_BUCKET}/${_FIRMWARE_COMPONENT}/${_TEST_TAG_NAME}/trusted_os_manifest_transparency_dev
+      - gs://${_LOG_NAME}/${_ENTRIES_DIR}/trusted_os_manifest
+  # Sequence log entry.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - call
+      - sequence
+      - '--data'
+      - '{"entriesDir": "${_ENTRIES_DIR}", "origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
+  # Integrate log entry.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - call
+      - integrate
+      - '--data'
+      - '{"origin": "${_ORIGIN}", "bucket": "${_LOG_NAME}"}'
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci
   _FIRMWARE_COMPONENT: trusted-os
   _TAMAGO_VERSION: '1.20.6'
   _TEST_TAG_NAME: '0.1.2'
+  # Log-related.
+  _ENTRIES_DIR: firmware-log-sequence
+  _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
+  _LOG_NAME: armored-witness-firmware-log-ci


### PR DESCRIPTION
This PR updates the Makefile and cloudbuild configs to store the os firmware binary in the correct CAS location.

See https://github.com/transparency-dev/armored-witness-common/pull/15