### PR TITLE
Improve os CI build pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.21-bookworm
 
 ARG TAMAGO_VERSION
+ARG FT_LOG_ORIGIN
+ARG LOG_PUBLIC_KEY
+ARG APPLET_PUBLIC_KEY
+ARG GIT_SEMVER_TAG
 
 # Install dependencies.
 RUN apt-get update && apt-get install -y make wget u-boot-tools binutils-arm-none-eabi
@@ -13,5 +17,11 @@ ENV TAMAGO=/usr/local/tamago-go/bin/go
 WORKDIR /build
 
 COPY . .
+
+# Firmware transparency parameters for output binary.
+ENV FT_LOG_ORIGIN=${FT_LOG_ORIGIN} \
+    LOG_PUBLIC_KEY=${LOG_PUBLIC_KEY} \
+    APPLET_PUBLIC_KEY=${APPLET_PUBLIC_KEY} \
+    GIT_SEMVER_TAG=${GIT_SEMVER_TAG}
 
 RUN make trusted_os_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG TAMAGO_VERSION
 # Install dependencies.
 RUN apt-get update && apt-get install -y make wget u-boot-tools binutils-arm-none-eabi
 
-RUN wget "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
-RUN tar -xvf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /
+RUN wget --quiet "https://github.com/usbarmory/tamago-go/releases/download/tamago-go${TAMAGO_VERSION}/tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz"
+RUN tar -xf "tamago-go${TAMAGO_VERSION}.linux-amd64.tar.gz" -C /
 # Set Tamago path for Make rule.
 ENV TAMAGO=/usr/local/tamago-go/bin/go
 

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -69,8 +69,8 @@ steps:
       - run
       - github.com/transparency-dev/armored-witness/cmd/sign
       - --project_name=${PROJECT_ID}
-      - --release="ci"
-      - --artefact="os1"
+      - --release=ci
+      - --artefact=os1
       - --manifest_file=output/trusted_os_manifest_unsigned.json
       - --output_file=output/trusted_os_manifest_transparency_dev
   # Print the content of the signed manifest.

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -123,9 +123,7 @@ steps:
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci
-  _FIRMWARE_COMPONENT: trusted-os
   _TAMAGO_VERSION: '1.20.6'
-  _TEST_TAG_NAME: '0.1.2'
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -52,11 +52,6 @@ steps:
       - output/trusted_os.elf
       - gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_os.elf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
-  - name: golang
-    args:
-      - go
-      - get
-      - github.com/transparency-dev/armored-witness/cmd/manifest
   # Create the manifest.
   # This step needs to be a bash script in order to substitute the fake take
   # in the command args.
@@ -65,7 +60,7 @@ steps:
     args:
       - -c
       - |
-        go run github.com/transparency-dev/armored-witness/cmd/manifest \
+        go run github.com/transparency-dev/armored-witness/cmd/manifest@${_ARMORED_WITNESS_REPO_VERSION} \
           create \
           --git_tag=$(cat /workspace/fake_tag) \
           --git_commit_fingerprint=${COMMIT_SHA} \
@@ -79,13 +74,8 @@ steps:
   - name: golang
     args:
       - go
-      - get
-      - github.com/transparency-dev/armored-witness/cmd/sign
-  - name: golang
-    args:
-      - go
       - run
-      - github.com/transparency-dev/armored-witness/cmd/sign
+      - github.com/transparency-dev/armored-witness/cmd/sign@${_ARMORED_WITNESS_REPO_VERSION}
       - --project_name=${PROJECT_ID}
       - --release=ci
       - --artefact=os1
@@ -124,6 +114,7 @@ substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci
   _TAMAGO_VERSION: '1.20.6'
+  _ARMORED_WITNESS_REPO_VERSION: d37d6b19ec4dbd1cad3586ae8ba3ec913829d718
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -46,11 +46,11 @@ steps:
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: bash
     args:
-      - gcloud
-      - storage
-      - cp
-      - output/trusted_os.elf
-      - gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_os.elf | cut -f1 -d" ")
+      - -c
+      - |
+        gcloud storage cp \
+          output/trusted_os.elf \
+          gs://${_FIRMWARE_BUCKET}/$(sha256sum output/trusted_os.elf | cut -f1 -d" ")
   ### Construct log entry / Claimant Model statement.
   # Create the manifest.
   # This step needs to be a bash script in order to substitute the fake take

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -1,15 +1,29 @@
 steps:
+  # First create a fake tag we'll use throughout the CI build process below.
+  # Unfortunately, GCB has no concept of dynamically creating substitutions or
+  # passing ENV vars between steps, so the best we can do is to create a file
+  # containing our tag in the share workspace which other steps can inspect.
+  - name: bash
+    script: |
+      date +'0.2.%s-incompatible' > /workspace/fake_tag
+      cat /workspace/fake_tag
   ### Build the Trusted OS, create a detached signature for it, and upload both to GCS.
   # Build an image containing the Trusted OS artifacts with the Dockerfile.
+  # This step needs to be a bash script in order to substitute fake tag into a
+  # build arg.
   - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - build
-      - --build-arg
-      - TAMAGO_VERSION=${_TAMAGO_VERSION}
-      - -t
-      - builder-image
-      # Path is relative to the root of the repo.
-      - .
+      - -c
+      - |
+        docker build \
+          --build-arg=TAMAGO_VERSION=${_TAMAGO_VERSION} \
+          --build-arg=FT_LOG_ORIGIN=${_ORIGIN} \
+          --build-arg=LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY} \
+          --build-arg=APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY} \
+          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
+          -t builder-image \
+          .
   # Prepare a container with a copy of the artifacts.
   - name: gcr.io/cloud-builders/docker
     args:
@@ -43,19 +57,23 @@ steps:
       - go
       - get
       - github.com/transparency-dev/armored-witness/cmd/manifest
+  # Create the manifest.
+  # This step needs to be a bash script in order to substitute the fake take
+  # in the command args.
   - name: golang
+    entrypoint: bash
     args:
-      - go
-      - run
-      - github.com/transparency-dev/armored-witness/cmd/manifest
-      - create
-      - --git_tag=${_TEST_TAG_NAME}
-      - --git_commit_fingerprint=${COMMIT_SHA}
-      - --firmware_file=output/trusted_os.elf
-      - --firmware_type=TRUSTED_OS
-      - --tamago_version=${_TAMAGO_VERSION}
-      - --raw
-      - --output_file=output/trusted_os_manifest_unsigned.json
+      - -c
+      - |
+        go run github.com/transparency-dev/armored-witness/cmd/manifest \
+          create \
+          --git_tag=$(cat /workspace/fake_tag) \
+          --git_commit_fingerprint=${COMMIT_SHA} \
+          --firmware_file=output/trusted_os.elf \
+          --firmware_type=TRUSTED_OS \
+          --tamago_version=${_TAMAGO_VERSION} \
+          --raw \
+          --output_file=output/trusted_os_manifest_unsigned.json
   # Sign the log entry.
   # TODO: sign the manifest twice to mimic the WithSecure 2nd signature flow.
   - name: golang
@@ -112,3 +130,5 @@ substitutions:
   _ENTRIES_DIR: firmware-log-sequence
   _ORIGIN: transparency.dev/armored-witness/firmware_transparency/ci/0
   _LOG_NAME: armored-witness-firmware-log-ci
+  _LOG_PUBLIC_KEY: transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu
+  _APPLET_PUBLIC_KEY: transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3


### PR DESCRIPTION
This PR makes a number of improvements to the CI build pipeline:

- Uses an incrementing "fake" tag for builds, so that witness devices can track updates from the log
- Fixes incorrect key hashes
- Small speed up from reducing logging volume