### PR TITLE
Bump to TamaGo v1.21.3

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.21.0
+      TAMAGO_VERSION: 1.21.3
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>
 
 PROTOC ?= /usr/bin/protoc
 
+TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
+MINIMUM_TAMAGO_VERSION=1.21.3
+
 SHELL = /bin/bash
 
 ifeq ("${DEBUG}","1")
@@ -204,6 +207,10 @@ check_tamago:
 		echo 'You need to set the TAMAGO variable to a compiled version of https://github.com/usbarmory/tamago-go'; \
 		exit 1; \
 	fi
+	@if [ "$(shell printf '%s\n' ${MINIMUM_TAMAGO_VERSION} ${TAMAGO_SEMVER} | sort -V | head -n1 )" != "${MINIMUM_TAMAGO_VERSION}" ]; then \
+		echo "You need TamaGo >= ${MINIMUM_TAMAGO_VERSION}, found ${TAMAGO_SEMVER}" ; \
+		exit 1; \
+	fi
 
 dcd:
 	cp -f $(GOMODCACHE)/$(TAMAGO_PKG)/board/usbarmory/mk2/imximage.cfg $(CURDIR)/bin/$(APP).dcd
@@ -224,7 +231,6 @@ qemu-gdb: trusted_os_embedded_applet
 $(APP).elf: check_tamago
 	cd $(DIR) && $(GOENV) $(TAMAGO) build -tags ${BUILD_TAGS} $(GOFLAGS) -o $(CURDIR)/bin/$(APP).elf
 
-$(APP)_manifest: TAMAGO_SEMVER=$(shell ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
 $(APP)_manifest:
 	# Create manifest
 	@echo ---------- Manifest --------------

--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -124,7 +124,7 @@ steps:
 substitutions:
   # Build-related.
   _FIRMWARE_BUCKET: armored-witness-firmware-ci
-  _TAMAGO_VERSION: '1.20.6'
+  _TAMAGO_VERSION: '1.21.3'
   _ARMORED_WITNESS_REPO_VERSION: e7141b6db638c3a2cb23e354cedd2d2980d0fb3a
   # Log-related.
   _ENTRIES_DIR: firmware-log-sequence


### PR DESCRIPTION
This PR bumps the version of TamaGo used to build and test to `1.21.3` (required due to recent changes to support `BEE`), and adds a check to the `Makefile` to ensure that a `TamaGo` version at least this new is always used to compile binaries.