### PR TITLE
Don't embed build info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ BUILD_HOST ?= $(shell hostname)
 BUILD_DATE ?= $(shell /bin/date -u "+%Y-%m-%d %H:%M:%S")
 BUILD_EPOCH := $(shell /bin/date -u "+%s")
 BUILD_TAGS = linkramsize,linkramstart,disable_fr_auth,linkprintk
-BUILD = ${BUILD_USER}@${BUILD_HOST} on ${BUILD_DATE}
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 GIT_SEMVER_TAG ?= $(shell (git describe --tags --exact-match --match 'v*.*.*' 2>/dev/null || git describe --match 'v*.*.*' --tags 2>/dev/null || git describe --tags 2>/dev/null || echo -n v0.0.${BUILD_EPOCH}+`git rev-parse HEAD`) | tail -c +2 )
 
@@ -51,7 +50,6 @@ ARCH = "arm"
 
 GOFLAGS = -tags ${BUILD_TAGS} -trimpath \
 	-ldflags "-T ${TEXT_START} -E ${ENTRY_POINT} -R 0x1000 \
-		-X 'main.Build=${BUILD}' \
 		-X 'main.Revision=${REV}' \
 		-X 'main.Version=${GIT_SEMVER_TAG}' \
 		-X 'main.AppletLogVerifier=$(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})' \
@@ -78,7 +76,7 @@ trusted_os_embedded_applet:
 witnessctl: check_tamago
 	@echo "building armored-witness control tool"
 	@cd $(CURDIR)/cmd/witnessctl && GOPATH="${BUILD_GOPATH}" ${TAMAGO} build -v \
-		-ldflags "-s -w -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}'" \
+		-ldflags "-s -w -X 'main.Revision=${REV}'" \
 		-o $(CURDIR)/bin/witnessctl
 
 # This target builds the Trusted OS without signing it as it is intended to be

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_USER ?= $(shell whoami)
-BUILD_HOST ?= $(shell hostname)
-BUILD_DATE ?= $(shell /bin/date -u "+%Y-%m-%d %H:%M:%S")
 BUILD_EPOCH := $(shell /bin/date -u "+%s")
 BUILD_TAGS = linkramsize,linkramstart,disable_fr_auth,linkprintk
 REV = $(shell git rev-parse --short HEAD 2> /dev/null)

--- a/api/api.go
+++ b/api/api.go
@@ -95,7 +95,6 @@ func (p *Status) Print() string {
 	status.WriteString(fmt.Sprintf("Serial number ..........: %s\n", p.Serial))
 	status.WriteString(fmt.Sprintf("Secure Boot ............: %v\n", p.HAB))
 	status.WriteString(fmt.Sprintf("Revision ...............: %s\n", p.Revision))
-	status.WriteString(fmt.Sprintf("Build ..................: %s\n", p.Build))
 	status.WriteString(fmt.Sprintf("Version ................: %d (%s)\n", p.Version, time.Unix(int64(p.Version), 0)))
 	status.WriteString(fmt.Sprintf("Runtime ................: %s\n", p.Runtime))
 	status.WriteString(fmt.Sprintf("Link ...................: %v\n", p.Link))

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -37,9 +37,12 @@ import (
 	_ "github.com/transparency-dev/armored-witness-os/rpmb"
 )
 
+const (
+	Build = ""
+)
+
 // initialized at compile time (see Makefile)
 var (
-	Build                  string
 	Revision               string
 	Version                string
 	AppletLogVerifier      string


### PR DESCRIPTION
This information isn't useful and makes it hard to reproducibly build the same output. If it was still useful then we could add it to the manifest, but it isn't, and so it is being removed. Removing this from the APIs here would be a backwards incompatible change, so the Build still exists in code, but as an empty string constant.
