### PR TITLE
Add support for chunked firmware updates

### DIFF
--- a/api/rpc/rpc.go
+++ b/api/rpc/rpc.go
@@ -51,8 +51,11 @@ type WitnessStatus struct {
 	IP string
 }
 
-// FirmwareUpdate represents a firmware update
+// FirmwareUpdate represents a firmware update.
 type FirmwareUpdate struct {
+	// Sequence is a counter used to ensure correct ordering of chunks of firmware.
+	Sequence uint
+
 	// Image is the firmware image to be applied.
 	Image []byte
 


### PR DESCRIPTION
This PR allows the applet to break up firmware-update requests to the OS into multiple, smaller, chunks.

Occasionally we've observed an OOM situation in the OS when trying to do a firmware update, this is usually after the device has been running for some time.

I suspect this is due to a combination of memory becoming fragmented over time, and the fact that, internally, the RPC mechanism is built using Go's [jsonrpc](https://pkg.go.dev/net/rpc/jsonrpc) so the already large firmware blobs are being further expanded by Base64 encoding. 