### PR TITLE
Add support for A/B partitions for OS and Applet firmware

### DIFF
--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -309,16 +309,16 @@ func flashFirmware(storage Card, t FirmwareType, elf []byte, pb config.ProofBund
 		return err
 	}
 
-	log.Printf("SM flashing %s config (%d bytes) @ 0x%x", t, len(confEnc), confBlock)
-
-	if err = flash(storage, confEnc, confBlock); err != nil {
-		return fmt.Errorf("%s signature flashing error: %v", t, err)
-	}
-
+	// Log firmware bytes first before updating config so that in case of any error the unit
+	// will still boot the previous working firmware.
 	log.Printf("SM flashing %s (%d bytes) @ 0x%x", t, len(elf), elfBlock)
-
 	if err = flash(storage, elf, elfBlock); err != nil {
 		return fmt.Errorf("%s flashing error: %v", t, err)
+	}
+
+	log.Printf("SM flashing %s config (%d bytes) @ 0x%x", t, len(confEnc), confBlock)
+	if err = flash(storage, confEnc, confBlock); err != nil {
+		return fmt.Errorf("%s signature flashing error: %v", t, err)
 	}
 
 	log.Printf("SM %s update complete", t)

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -122,6 +122,14 @@ func determineLoadedOSBlock(card Card) error {
 	}
 
 	osLoadedFromBlock = conf.Offset / expectedBlockSize
+	switch osLoadedFromBlock {
+	case osBlockA:
+		log.Print("Loaded OS from slot A")
+	case osBlockB:
+		log.Print("Loaded OS from slot B")
+	default:
+		log.Printf("Loaded OS from unexpected block %d", osLoadedFromBlock)
+	}
 	return nil
 }
 
@@ -151,6 +159,14 @@ func read(card Card) (fw *firmware.Bundle, err error) {
 	}
 
 	appletLoadedFromBlock = conf.Offset / expectedBlockSize
+	switch appletLoadedFromBlock {
+	case taBlockA:
+		log.Print("Loaded applet from slot A")
+	case taBlockB:
+		log.Print("Loaded applet from slot B")
+	default:
+		log.Printf("Loaded applet from unexpected block %d", appletLoadedFromBlock)
+	}
 
 	return
 }

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -108,8 +108,8 @@ func readConfig(card Card, configBlock int64) (*config.Config, error) {
 	return conf, nil
 }
 
-// determineLoadedOSBlock reads the currently stored OS config, and stores the
-// MMC block index where the corresponding firmware image can be found in osLoadedFromBlock.
+// determineLoadedOSBlock reads the current OS config, and updates osLoadedFromBlock with the
+// MMC block index where the corresponding firmware image can be found.
 func determineLoadedOSBlock(card Card) error {
 	blockSize := card.Info().BlockSize
 	if blockSize != expectedBlockSize {
@@ -135,6 +135,9 @@ func determineLoadedOSBlock(card Card) error {
 
 // read reads the trusted applet bundle from internal storage, the
 // applet and FT proofs are *not* verified by this function.
+//
+// This function will update appletLoadedFromBlock with the MMC block index
+// the applet firmware image was loaded from.
 func read(card Card) (fw *firmware.Bundle, err error) {
 	blockSize := card.Info().BlockSize
 	if blockSize != expectedBlockSize {
@@ -311,7 +314,7 @@ func flashFirmware(storage Card, t FirmwareType, elf []byte, pb config.ProofBund
 
 	// Log firmware bytes first before updating config so that in case of any error the unit
 	// will still boot the previous working firmware.
-	log.Printf("SM flashing %s (%d bytes) @ 0x%x", t, len(elf), elfBlock)
+	log.Printf("!SM flashing %s (%d bytes) @ 0x%x", t, len(elf), elfBlock)
 	if err = flash(storage, elf, elfBlock); err != nil {
 		return fmt.Errorf("%s flashing error: %v", t, err)
 	}

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -312,9 +312,9 @@ func flashFirmware(storage Card, t FirmwareType, elf []byte, pb config.ProofBund
 		return err
 	}
 
-	// Log firmware bytes first before updating config so that in case of any error the unit
+	// Flash firmware bytes first before updating config so that in case of any error the unit
 	// will still boot the previous working firmware.
-	log.Printf("!SM flashing %s (%d bytes) @ 0x%x", t, len(elf), elfBlock)
+	log.Printf("SM flashing %s (%d bytes) @ 0x%x", t, len(elf), elfBlock)
 	if err = flash(storage, elf, elfBlock); err != nil {
 		return fmt.Errorf("%s flashing error: %v", t, err)
 	}

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -160,6 +160,10 @@ func main() {
 		}
 	}
 
+	if err := determineLoadedOSBlock(Storage); err != nil {
+		log.Printf("Failed to determine OS MMC block (no OS installed?): %v", err)
+	}
+
 	log.Printf("SM log verification pub: %s", AppletLogVerifier)
 	logVerifier, err := note.NewVerifier(AppletLogVerifier)
 	if err != nil {


### PR DESCRIPTION
This PR attempts to increase device resilience in the face of update failures by adding support for an A/B firmware scheme for both the OS and Applet firmware images.

At boot time, the device figures out which of the A/B slots were used to load the OS/Applet from, and then uses this information when auto-updating to write newer firmware to the _other_ slot. If there was an error during update, the previously booted firmware should remain intact and will be used when the device reboots/is rebooted.

This isn't 100% watertight due to how the config gets updated, but significantly reduces the window during which an power failure/crash/etc. can cause the device firmware to become corrupt (from ~20MB of writes down to ~1KB).

Changes are contained here - no updates to support this are necessary in the bootloader or applet.