### PR TITLE
OS update verifies FT bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ GOFLAGS = -tags ${BUILD_TAGS} -trimpath -buildvcs=false -buildmode=exe \
 	-ldflags "-T ${TEXT_START} -E ${ENTRY_POINT} -R 0x1000 \
 		-X 'main.Revision=${REV}' \
 		-X 'main.Version=${GIT_SEMVER_TAG}' \
-		-X 'main.AppletLogVerifier=$(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})' \
-		-X 'main.AppletLogOrigin=${LOG_ORIGIN}' \
-		-X 'main.AppletManifestVerifier=$(shell test ${APPLET_PUBLIC_KEY} && cat ${APPLET_PUBLIC_KEY})'"
+		-X 'main.LogVerifier=$(shell test ${LOG_PUBLIC_KEY} && cat ${LOG_PUBLIC_KEY})' \
+		-X 'main.LogOrigin=${LOG_ORIGIN}' \
+		-X 'main.AppletManifestVerifier=$(shell test ${APPLET_PUBLIC_KEY} && cat ${APPLET_PUBLIC_KEY})' \
+		-X 'main.OSManifestVerifier1=$(shell test ${OS_PUBLIC_KEY1} && cat ${OS_PUBLIC_KEY1})' \
+		-X 'main.OSManifestVerifier2=$(shell test ${OS_PUBLIC_KEY2} && cat ${OS_PUBLIC_KEY2})'"
 
 .PHONY: clean qemu qemu-gdb
 
@@ -171,6 +173,14 @@ check_embed_env:
 	fi
 	@if [ "${APPLET_PUBLIC_KEY}" == "" ] || [ ! -f "${APPLET_PUBLIC_KEY}" ]; then \
 		echo 'You need to set the APPLET_PUBLIC_KEY variable to a valid note verifier key path'; \
+		exit 1; \
+	fi
+	@if [ "${OS_PUBLIC_KEY1}" == "" ] || [ ! -f "${OS_PUBLIC_KEY1}" ]; then \
+		echo 'You need to set the OS_PUBLIC_KEY1 variable to a valid note verifier key path'; \
+		exit 1; \
+	fi
+	@if [ "${OS_PUBLIC_KEY2}" == "" ] || [ ! -f "${OS_PUBLIC_KEY2}" ]; then \
+		echo 'You need to set the OS_PUBLIC_KEY2 variable to a valid note verifier key path'; \
 		exit 1; \
 	fi
 

--- a/trusted_os/flash.go
+++ b/trusted_os/flash.go
@@ -257,7 +257,19 @@ func updateApplet(storage Card, taELF []byte, pb config.ProofBundle) (err error)
 
 // updateOS verifies an OS update and flashes it to internal storage
 func updateOS(storage Card, osELF []byte, pb config.ProofBundle) (err error) {
-	// TODO: OS proof bundle verification
+	// First, verify everything is correct and that, as far as we can tell,
+	// we would succeed in loadering and launching this applet upon next boot.
+	bundle := firmware.Bundle{
+		Checkpoint:     pb.Checkpoint,
+		Index:          pb.LogIndex,
+		InclusionProof: pb.InclusionProof,
+		Manifest:       pb.Manifest,
+		Firmware:       osELF,
+	}
+	if _, err := OSBundleVerifier.Verify(bundle); err != nil {
+		return err
+	}
+	log.Printf("SM verified applet bundle for update")
 
 	return flashFirmware(storage, Firmware_OS, osELF, pb)
 }


### PR DESCRIPTION
This PR adds the requirement that OS updates must also pass FT verification, bringing this path into line with the existing check during Applet updates.

(@mhutchinson in case these changes affect the [reproducible build verifier](https://github.com/transparency-dev/armored-witness/tree/main/verifier/build) in any way).