### PR TITLE
Bump CI version to 0.3.X

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -5,7 +5,7 @@ steps:
   # containing our tag in the share workspace which other steps can inspect.
   - name: bash
     script: |
-      date +'0.0.%s-incompatible' > /workspace/fake_tag
+      date +'0.3.%s-incompatible' > /workspace/fake_tag
       cat /workspace/fake_tag
   ### Build the Trusted OS and upload it to GCS.
   # Build an image containing the Trusted OS artifacts with the Dockerfile.


### PR DESCRIPTION
This was downgraded from 0.2.X to 0.0.X because it seemed arbitrary. This caused a latent problem that has now come to light as we're trying to flash these CI builds onto the devices, which is that recent builds appear older than those from before the version downgrade. In the interests of being pragmatic, bumping this version to a newer version bypasses this problem. We can reset this to 0.0.X again should we ever rotate the CI logs.
