### PR TITLE
Add fake RPMB.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ endif
 ifeq ("${FAKE_STORAGE}", "1")
 	BUILD_TAGS := ${BUILD_TAGS},fake_storage
 endif
+ifeq ("${FAKE_RPMB}", "1")
+	BUILD_TAGS := ${BUILD_TAGS},fake_rpmb
+endif
 
 APP := ""
 TEXT_START = 0x80010000 # ramStart (defined in mem.go under relevant tamago/soc package) + 0x10000

--- a/rpmb/op.go
+++ b/rpmb/op.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	frameLength = 512
+	FrameLength = 512
 	macOffset   = 284
 )
 
@@ -112,7 +112,7 @@ func (p *RPMB) op(req *DataFrame, cfg *Config) (res *DataFrame, err error) {
 	mac := hmac.New(sha256.New, p.key[:])
 
 	if cfg.RequestMAC {
-		mac.Write(req.Bytes()[frameLength-macOffset:])
+		mac.Write(req.Bytes()[FrameLength-macOffset:])
 		copy(req.KeyMAC[:], mac.Sum(nil))
 		mac.Reset()
 	}
@@ -145,7 +145,7 @@ func (p *RPMB) op(req *DataFrame, cfg *Config) (res *DataFrame, err error) {
 		}
 	}
 
-	buf := make([]byte, frameLength)
+	buf := make([]byte, FrameLength)
 	res = &DataFrame{}
 
 	// read response
@@ -161,7 +161,7 @@ func (p *RPMB) op(req *DataFrame, cfg *Config) (res *DataFrame, err error) {
 	// validate response
 
 	if cfg.ResponseMAC {
-		mac.Write(buf[frameLength-macOffset:])
+		mac.Write(buf[FrameLength-macOffset:])
 
 		if !hmac.Equal(res.KeyMAC[:], mac.Sum(nil)) {
 			return nil, errors.New("invalid response MAC")
@@ -186,7 +186,7 @@ func (p *RPMB) op(req *DataFrame, cfg *Config) (res *DataFrame, err error) {
 }
 
 func (p *RPMB) transfer(kind byte, offset uint16, buf []byte) (err error) {
-	if len(buf) > frameLength/2 {
+	if len(buf) > FrameLength/2 {
 		return errors.New("transfer size must not exceed 256 bytes")
 	}
 

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -134,11 +134,16 @@ func main() {
 	usbarmory.LED("blue", false)
 	usbarmory.LED("white", false)
 
-	Storage, rpmb := storage()
+	Storage := storage()
 	if Storage != nil {
 		if err = Storage.Detect(); err != nil {
 			log.Fatalf("SM failed to detect storage, %v", err)
 		}
+	}
+
+	rpmb, err := newRPMB(Storage)
+	if err != nil {
+		log.Fatalf("SM could not initialize rollback protection, %v", err)
 	}
 
 	rpc := &RPC{
@@ -154,10 +159,6 @@ func main() {
 	// TODO: disable for now
 	if false && imx6ul.SNVS.Available() {
 		log.Printf("SM version verification (%s)", Version)
-
-		if err = rpmb.init(); err != nil {
-			log.Fatalf("SM could not initialize rollback protection, %v", err)
-		}
 
 		if err = rpmb.checkVersion(osVersionSector, Version); err != nil {
 			log.Fatalf("SM firmware rollback check failure, %v", err)

--- a/trusted_os/rpmb.go
+++ b/trusted_os/rpmb.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !fake_rpmb
+// +build !fake_rpmb
+
 package main
 
 import (
@@ -90,7 +93,7 @@ func newRPMB(storage Card) (r *RPMB, err error) {
 		dummySector,
 	)
 	if err != nil {
-		return nil, errors.New("could not init RPMB TODO")
+		return nil, fmt.Errorf("RPMB could not be initialized: %v", err)
 	}
 
 	var e *rpmb.OperationError

--- a/trusted_os/rpmb_fake.go
+++ b/trusted_os/rpmb_fake.go
@@ -37,11 +37,11 @@ const (
 	taUserSector = 3
 
 	sectorLength = 256
-	memoryLength = 1024
+	numSectors   = 16
 )
 
 type RPMB struct {
-	mem     [memoryLength]byte
+	mem     [numSectors][sectorLength]byte
 	counter uint32
 }
 
@@ -62,7 +62,7 @@ func parseVersion(s string) (version uint32, err error) {
 // expectedVersion returns the version epoch stored in a fake RPMB area.
 func (r *RPMB) expectedVersion(sector uint16) (version uint32, err error) {
 	buf := make([]byte, versionLength)
-	copy(buf, r.mem[sector*sectorLength:])
+	copy(buf, r.mem[sector])
 
 	return binary.BigEndian.Uint32(buf), nil
 }
@@ -72,7 +72,7 @@ func (r *RPMB) updateVersion(sector uint16, version uint32) (err error) {
 	buf := make([]byte, versionLength)
 	binary.BigEndian.PutUint32(buf, version)
 
-	copy(r.mem[sector*sectorLength:], buf)
+	copy(r.mem[sector], buf)
 	r.counter++
 
 	return nil
@@ -119,10 +119,10 @@ func (r *RPMB) transfer(sector uint16, buf []byte, n *uint32, write bool) (err e
 	}
 
 	if write {
-		copy(r.mem[sector*sectorLength:], buf)
+		copy(r.mem[sector], buf)
 		r.counter++
 	} else {
-		copy(buf, r.mem[sector*sectorLength:])
+		copy(buf, r.mem[sector])
 	}
 
 	if n != nil {

--- a/trusted_os/rpmb_fake.go
+++ b/trusted_os/rpmb_fake.go
@@ -125,6 +125,8 @@ func (r *RPMB) transfer(sector uint16, buf []byte, n *uint32, write bool) (err e
 		copy(buf, r.mem[sector*sectorLength:])
 	}
 
-	*n = r.counter
+	if n != nil {
+		*n = r.counter
+	}
 	return
 }

--- a/trusted_os/rpmb_fake.go
+++ b/trusted_os/rpmb_fake.go
@@ -1,0 +1,130 @@
+// Copyright 2022 The Armored Witness OS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fake_rpmb
+// +build fake_rpmb
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"strconv"
+
+	"github.com/transparency-dev/armored-witness-os/rpmb"
+)
+
+const (
+	// version epoch length
+	versionLength = 4
+	// RPMB sector for OS rollback protection
+	osVersionSector = 1
+	// RPMB sector for TA rollback protection
+	taVersionSector = 2
+
+	// RPMB sector for TA use
+	taUserSector = 3
+
+	sectorLength = 256
+	memoryLength = 1024
+)
+
+type RPMB struct {
+	mem     [memoryLength]byte
+	counter uint32
+}
+
+func newRPMB(_ Card) (*RPMB, error) {
+	return &RPMB{}, nil
+}
+
+func parseVersion(s string) (version uint32, err error) {
+	v, err := strconv.Atoi(s)
+
+	if err != nil {
+		return
+	}
+
+	return uint32(v), nil
+}
+
+// expectedVersion returns the version epoch stored in a fake RPMB area.
+func (r *RPMB) expectedVersion(sector uint16) (version uint32, err error) {
+	buf := make([]byte, versionLength)
+	copy(buf, r.mem[sector*sectorLength:])
+
+	return binary.BigEndian.Uint32(buf), nil
+}
+
+// updateVersion writes a new version epoch in a fake RPMB area.
+func (r *RPMB) updateVersion(sector uint16, version uint32) (err error) {
+	buf := make([]byte, versionLength)
+	binary.BigEndian.PutUint32(buf, version)
+
+	copy(r.mem[sector*sectorLength:], buf)
+	r.counter++
+
+	return nil
+}
+
+// checkVersion verifies version information against fake RPMB stored data.
+//
+// If the passed version is older than the RPMB area information of the
+// internal eMMC an error is returned.
+//
+// If the passed version is more recent than the RPMB area information then the
+// internal eMMC is updated with it.
+func (r *RPMB) checkVersion(sector uint16, s string) (err error) {
+	version, err := parseVersion(s)
+
+	if err != nil {
+		return
+	}
+
+	expectedVersion, err := r.expectedVersion(sector)
+
+	if err != nil {
+		return
+	}
+
+	switch {
+	case expectedVersion > version:
+		return errors.New("version mismatch")
+	case expectedVersion == version:
+		return
+	case expectedVersion < version:
+		return r.updateVersion(sector, version)
+	}
+
+	return
+}
+
+// transfer performs a data transfer to the fake RPMB area,
+// the input buffer can contain up to 256 bytes of data, n can be passed to
+// retrieve the write counter.
+func (r *RPMB) transfer(sector uint16, buf []byte, n *uint32, write bool) (err error) {
+	if len(buf) > rpmb.FrameLength/2 {
+		return errors.New("transfer size must not exceed 256 bytes")
+	}
+
+	if write {
+		copy(r.mem[sector*sectorLength:], buf)
+		r.counter++
+	} else {
+		copy(buf, r.mem[sector*sectorLength:])
+	}
+
+	*n = r.counter
+	return
+}

--- a/trusted_os/storage.go
+++ b/trusted_os/storage.go
@@ -21,7 +21,6 @@ import (
 	usbarmory "github.com/usbarmory/tamago/board/usbarmory/mk2"
 )
 
-func storage() (Card, *RPMB) {
-	s := usbarmory.MMC
-	return s, &RPMB{storage: s}
+func storage() Card {
+	return usbarmory.MMC
 }

--- a/trusted_os/storage_debug.go
+++ b/trusted_os/storage_debug.go
@@ -35,12 +35,11 @@ const (
 
 // storage will return MMC backed storage if running on real hardware, or
 // a fake in-memory storage device otherwise.
-func storage() (Card, *RPMB) {
+func storage() Card {
 	if imx6ul.Native {
-		s := usbarmory.MMC
-		return s, &RPMB{storage: s}
+		return usbarmory.MMC
 	}
-	return newFakeCard(fakeCardNumBlocks), &RPMB{}
+	return newFakeCard(fakeCardNumBlocks)
 }
 
 // fakeCard is an implementation of an in-memory storage device.


### PR DESCRIPTION
Add an implementation of fake RPMB storage so that we can keep a counter for the witness identity in case the device needs to be wiped and a new identity needs to be doled out. This counter will be used in deriving the witness key in the applet.

Tried to write some testing, but even moving `trusted_os/rpmb*` stuff out of package `main` still requires Tamago, because the real rpmb implementation imports Tamago.