### PR TITLE
Commit to all build envs in manifest

### DIFF
--- a/release/cloudbuild_ci.yaml
+++ b/release/cloudbuild_ci.yaml
@@ -18,12 +18,12 @@ steps:
       - |
         docker build \
           --build-arg=TAMAGO_VERSION=${_TAMAGO_VERSION} \
+          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=LOG_ORIGIN=${_ORIGIN} \
           --build-arg=LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY} \
           --build-arg=APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY} \
           --build-arg=OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1} \
           --build-arg=OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2} \
-          --build-arg=GIT_SEMVER_TAG=$(cat /workspace/fake_tag) \
           --build-arg=BEE=${_BEE} \
           --build-arg=DEBUG=${_DEBUG} \
           -t builder-image \
@@ -71,6 +71,11 @@ steps:
           --firmware_file=output/trusted_os.elf \
           --firmware_type=TRUSTED_OS \
           --tamago_version=${_TAMAGO_VERSION} \
+          --build_env="LOG_ORIGIN=${_ORIGIN}" \
+          --build_env="LOG_PUBLIC_KEY=${_LOG_PUBLIC_KEY}" \
+          --build_env="APPLET_PUBLIC_KEY=${_APPLET_PUBLIC_KEY}" \
+          --build_env="OS_PUBLIC_KEY1=${_OS_PUBLIC_KEY1}" \
+          --build_env="OS_PUBLIC_KEY2=${_OS_PUBLIC_KEY2}" \
           --build_env="BEE=${_BEE}" \
           --build_env="DEBUG=${_DEBUG}" \
           --raw \


### PR DESCRIPTION
Any of these values could be rotated in the future, and given they are critical for reproducible builds they should be in the manifest. One could argue that these should have their own top-level named entry in the manifest rather than being buried in build_envs. For pragmatism, let's use this approach for now and we can revisit this in a month as part of a whole manifest refactor before we commit to v1.
