### PR TITLE
Handle case where no rollback version was yet stored

### DIFF
--- a/trusted_os/rpmb.go
+++ b/trusted_os/rpmb.go
@@ -24,6 +24,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -165,6 +166,10 @@ func (r *RPMB) expectedVersion(offset uint16) (*semver.Version, error) {
 	}
 	var v string
 	if err := gob.NewDecoder(bytes.NewBuffer(buf)).Decode(&v); err != nil {
+		if err == io.EOF {
+			// We've not previously stored a version, so return 0.0.0
+			return semver.NewVersion("0.0.0")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
```
00:00:03 RPMB program key flag already fused
00:00:03 SM firmware rollback check failure, EOF
```