### PR TITLE
DEV: Hang on applet exit

### DIFF
--- a/trusted_os/debug.go
+++ b/trusted_os/debug.go
@@ -177,15 +177,15 @@ func segfault(buf []byte, ctx *monitor.ExecCtx) (err error) {
 }
 
 func inspect(buf []byte, ctx *monitor.ExecCtx) (err error) {
-	if false {
-		log.Printf("PC\t%s", fileLine(buf, ctx.R15)) // PC
-		log.Printf("LR\t%s", fileLine(buf, ctx.R14)) // LR
+	log.Printf("PC\t%s", fileLine(buf, ctx.R15)) // PC
+	log.Printf("LR\t%s", fileLine(buf, ctx.R14)) // LR
 
-		switch ctx.ExceptionVector {
-		case arm.UNDEFINED, arm.PREFETCH_ABORT, arm.DATA_ABORT:
-			return segfault(buf, ctx)
-		}
+	switch ctx.ExceptionVector {
+	case arm.UNDEFINED, arm.PREFETCH_ABORT, arm.DATA_ABORT:
+		return segfault(buf, ctx)
 	}
 
+	// XXX block forever
+	<-make(chan bool, 1)
 	return
 }

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -252,13 +252,6 @@ func main() {
 
 	// never returns
 	handleInterrupts()
-
-	if debug {
-		// We never hit this due to handleInterrupts not returning, but having this line here
-		// forces the linker to keep the symbol present which is necessary for the inspect()
-		// function to work for debug builds.
-		runtime.CallOnG0()
-	}
 }
 
 func createBundleVerifier(logOrigin string, logVerifier note.Verifier, manifestVerifiers []string) (firmware.BundleVerifier, error) {


### PR DESCRIPTION
Temporarily cause the applet to hang if it crashes, rather than attempt a restart, to enable us to catch a rare event.