### PR TITLE
Re-enable applet version rollback check

### DIFF
--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -45,6 +45,11 @@ type RPC struct {
 
 // Version receives the Trusted Applet version for verification.
 func (r *RPC) Version(version string, _ *bool) error {
+	if !imx6ul.Native || !imx6ul.SNVS.Available() {
+		log.Print("SM skipping applet version verification")
+		return nil
+	}
+
 	log.Printf("SM applet version verification (%s)", version)
 
 	if err := r.RPMB.checkVersion(taVersionSector, version); err != nil {

--- a/trusted_os/rpc.go
+++ b/trusted_os/rpc.go
@@ -45,9 +45,6 @@ type RPC struct {
 
 // Version receives the Trusted Applet version for verification.
 func (r *RPC) Version(version string, _ *bool) error {
-	// TODO: disable for now
-	return nil
-
 	log.Printf("SM applet version verification (%s)", version)
 
 	if err := r.RPMB.checkVersion(taVersionSector, version); err != nil {


### PR DESCRIPTION
Perform the Applet version rollback check, but only on fused, real, h/w.