### PR TITLE
Make log fetching more stable

### DIFF
--- a/cmd/witnessctl/api.go
+++ b/cmd/witnessctl/api.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"time"
 
 	flynn_hid "github.com/flynn/hid"
 	"github.com/flynn/u2f/u2fhid"
@@ -105,9 +104,6 @@ func (d Device) getLogMessages(cmd byte) (string, error) {
 			}
 			w.Write(rsp.GetPayload())
 			req.Continue = true
-
-			// Don't overload the HID endpoint
-			time.Sleep(20 * time.Millisecond)
 		}
 	}()
 

--- a/trusted_os/ctl.go
+++ b/trusted_os/ctl.go
@@ -99,7 +99,7 @@ func getStatus() (s *api.Status) {
 	}
 
 	if imx6ul.Native {
-		s.HAB    = imx6ul.SNVS.Available()
+		s.HAB = imx6ul.SNVS.Available()
 		s.Serial = fmt.Sprintf("%X", imx6ul.UniqueID())
 	}
 
@@ -188,9 +188,10 @@ func (ctl *controlInterface) handleLogsRequest(r []byte, l func() []byte) (res [
 		log.Printf("Compressed %d bytes of log messages to %d send", ll, len(ctl.logBuffer))
 	}
 	ret := &api.LogMessagesResponse{}
-	if l := len(ctl.logBuffer); l > maxChunkSize {
+	logChunk := 1024
+	if l := len(ctl.logBuffer); l > logChunk {
 		ret.More = true
-		ret.Payload, ctl.logBuffer = ctl.logBuffer[:maxChunkSize], ctl.logBuffer[maxChunkSize:]
+		ret.Payload, ctl.logBuffer = ctl.logBuffer[:logChunk], ctl.logBuffer[logChunk:]
 	} else {
 		ret.More = false
 		ret.Payload = ctl.logBuffer


### PR DESCRIPTION
Reduce the size of the chunks of log data being sent back, as this seems to make it more stable.