### PR TITLE
Bump Tamago to 1.22.4

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     env:
-      TAMAGO_VERSION: 1.22.0
+      TAMAGO_VERSION: 1.22.4
       TAMAGO: /usr/local/tamago-go/bin/go
       APPLET_PRIVATE_KEY: /tmp/applet.sec
       APPLET_PUBLIC_KEY: /tmp/applet.pub

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRK_HASH ?=
 PROTOC ?= /usr/bin/protoc
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.22.0
+MINIMUM_TAMAGO_VERSION=1.22.4
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-os
 
-go 1.22.0
+go 1.22.4
 
 require (
 	github.com/coreos/go-semver v0.3.1


### PR DESCRIPTION
This PR bumps the minimum version of Tamago to 1.22.4 in prep for #256.

Needs transparency-dev/armored-witness#264 for presubmit.