### PR TITLE
Bump go and tamago to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRK_HASH ?=
 PROTOC ?= /usr/bin/protoc
 
 TAMAGO_SEMVER = $(shell [ -n "${TAMAGO}" -a -x "${TAMAGO}" ] && ${TAMAGO} version | sed 's/.*go\([0-9]\.[0-9]*\.[0-9]*\).*/\1/')
-MINIMUM_TAMAGO_VERSION=1.22.4
+MINIMUM_TAMAGO_VERSION=1.22.6
 
 SHELL = /bin/bash
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness-os
 
-go 1.22.4
+go 1.22.6
 
 require (
 	github.com/coreos/go-semver v0.3.1


### PR DESCRIPTION
Started on this journey because https://github.com/transparency-dev/armored-witness-common/pull/36 failed due to old version. May as well bring everything up to the latest version of tamago.
