### PR TITLE
add support to wake tamago < 1.23 applets on >= 1.23 os

### DIFF
--- a/trusted_os/handler.go
+++ b/trusted_os/handler.go
@@ -36,6 +36,7 @@ var irqHandler = make(map[int]func())
 
 // defined in handler.s
 func wakeHandler(g uint32, p uint32)
+func wakeHandlerPreGo122(g uint32, p uint32)
 
 func isr() {
 	irq := imx6ul.GIC.GetInterrupt(true)

--- a/trusted_os/handler.go
+++ b/trusted_os/handler.go
@@ -36,7 +36,7 @@ var irqHandler = make(map[int]func())
 
 // defined in handler.s
 func wakeHandler(g uint32, p uint32)
-func wakeHandlerPreGo122(g uint32, p uint32)
+func wakeHandlerPreGo123(g uint32, p uint32)
 
 func isr() {
 	irq := imx6ul.GIC.GetInterrupt(true)

--- a/trusted_os/handler.s
+++ b/trusted_os/handler.s
@@ -15,6 +15,12 @@
 #include "go_asm.h"
 #include "textflag.h"
 
+#define g_timer				208
+#define timer_nextwhen			36
+#define timer_status			44
+#define const_timerModifiedEarlier	7
+#define p_timerModifiedEarliest		2384
+
 TEXT ·wakeHandler(SB),$0-8
 	MOVW	handlerG+0(FP), R0
 	MOVW	handlerP+4(FP), R1
@@ -26,5 +32,39 @@ TEXT ·wakeHandler(SB),$0-8
 	B.EQ	done
 
 	B	runtime·WakeG(SB)
+done:
+	RET
+
+// In order to support applets built with tamago < 1.23 the previous version of
+// WakeG is made available here.
+TEXT ·wakeHandlerPreGo123(SB),$0-8
+	MOVW	handlerG+0(FP), R0
+	MOVW	handlerP+4(FP), R1
+
+	CMP	$0, R0
+	B.EQ	done
+
+	CMP	$0, R1
+	B.EQ	done
+
+	MOVW	(g_timer)(R0), R0
+	CMP	$0, R0
+	B.EQ	done
+
+	// g->timer.nextwhen = 1
+	MOVW	$1, R2
+	MOVW	R2, (timer_nextwhen+0)(R0)
+	MOVW	$0, R2
+	MOVW	R2, (timer_nextwhen+4)(R0)
+
+	// g->timer.status = timerModifiedEarlier
+	MOVW	$const_timerModifiedEarlier, R2
+	MOVW	R2, (timer_status+0)(R0)
+
+	// g->m->p.timerModifiedEarliest = 1
+	MOVW	$1, R2
+	MOVW	R2, (p_timerModifiedEarliest)(R1)
+	MOVW	$0, R2
+	MOVW	R2, (p_timerModifiedEarliest+4)(R1)
 done:
 	RET

--- a/trusted_os/handler.s
+++ b/trusted_os/handler.s
@@ -15,12 +15,16 @@
 #include "go_asm.h"
 #include "textflag.h"
 
+// These defines are only used to aid applet runtime backward compatiblity,
+// within wakeHandlerPreGo123, and represent timer structs offsets fo Go <
+// 1.23.
 #define g_timer				208
 #define timer_nextwhen			36
 #define timer_status			44
 #define const_timerModifiedEarlier	7
 #define p_timerModifiedEarliest		2384
 
+// Supports tamago >= 1.23 applet runtime.
 TEXT ·wakeHandler(SB),$0-8
 	MOVW	handlerG+0(FP), R0
 	MOVW	handlerP+4(FP), R1
@@ -35,8 +39,7 @@ TEXT ·wakeHandler(SB),$0-8
 done:
 	RET
 
-// In order to support applets built with tamago < 1.23 the previous version of
-// WakeG is made available here.
+// Supports tamago < 1.23 applet runtime.
 TEXT ·wakeHandlerPreGo123(SB),$0-8
 	MOVW	handlerG+0(FP), R0
 	MOVW	handlerP+4(FP), R1


### PR DESCRIPTION
This PR adds support for applets built with tamago < 1.23 by making available the previous version of runtime·WakeG.
