### PR TITLE
OS uses appropriate wakeHandler for applet runtime

### DIFF
--- a/trusted_os/handler.go
+++ b/trusted_os/handler.go
@@ -39,10 +39,14 @@ var irqHandler = make(map[int]func())
 func wakeHandler(g uint32, p uint32)
 func wakeHandlerPreGo123(g uint32, p uint32)
 
+// handlerCutover is the semver representation of the cut over between wakeHandler implementations above.
+// Anything less that this should use the legacy PreGo123 version.
+const handlerCutover = "1.23.0"
+
 var (
 	// wHandler is the wakeHandler implementation to be used, 1.23+ by default.
 	wHandler        = wakeHandler
-	wHandlerCutover = *semver.New("1.23.0")
+	wHandlerCutover = *semver.New(handlerCutover)
 )
 
 func configureWakeHandler(rtVersion semver.Version) {

--- a/trusted_os/handler.go
+++ b/trusted_os/handler.go
@@ -17,6 +17,7 @@ package main
 import (
 	"log"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/usbarmory/tamago/arm"
 	"github.com/usbarmory/tamago/bits"
 	"github.com/usbarmory/tamago/soc/nxp/imx6ul"
@@ -38,6 +39,21 @@ var irqHandler = make(map[int]func())
 func wakeHandler(g uint32, p uint32)
 func wakeHandlerPreGo123(g uint32, p uint32)
 
+var (
+	// wHandler is the wakeHandler implementation to be used, 1.23+ by default.
+	wHandler        = wakeHandler
+	wHandlerCutover = *semver.New("1.23.0")
+)
+
+func configureWakeHandler(rtVersion semver.Version) {
+	if rtVersion.LessThan(wHandlerCutover) {
+		wHandler = wakeHandlerPreGo123
+		log.Printf("SM Using legacy pre-%s wakeHandler", wHandlerCutover.String())
+	} else {
+		wHandler = wakeHandler
+	}
+}
+
 func isr() {
 	irq := imx6ul.GIC.GetInterrupt(true)
 
@@ -45,7 +61,7 @@ func isr() {
 		handle()
 		return
 	}
-	log.Printf("unexpected IRQ %d", irq)
+	log.Printf("SM unexpected IRQ %d", irq)
 }
 
 func fiqHandler(ctx *monitor.ExecCtx) (_ error) {
@@ -67,7 +83,7 @@ func fiqHandler(ctx *monitor.ExecCtx) (_ error) {
 	// mask FIQs, applet handler will request unmasking when done
 	bits.Set(&ctx.SPSR, CPSR_FIQ)
 
-	wakeHandler(appletHandlerG, appletHandlerP)
+	wHandler(appletHandlerG, appletHandlerP)
 
 	return
 }

--- a/trusted_os/main.go
+++ b/trusted_os/main.go
@@ -228,7 +228,10 @@ func main() {
 					log.Printf("SM applet verification error, %v", err)
 				}
 				loadedAppletVersion = manifest.Git.TagName
-				log.Printf("SM Loaded applet version %s", loadedAppletVersion.String())
+				loadedAppletRuntime := manifest.Build.TamagoVersion
+				log.Printf("SM Loaded applet version %s (with TamaGo runtime %s)", loadedAppletVersion.String(), loadedAppletRuntime.String())
+
+				configureWakeHandler(loadedAppletRuntime)
 
 				usbarmory.LED("white", true)
 


### PR DESCRIPTION
This PR allows the OS to inspect the version of TamaGo used to compile the applet, and select the appropriate mechanism for waking that runtime when necessary.

Boot log showing a 1.23 SM/OS launching a 1.22.4 Applet, using "legacy wake handler", and successfully receiving network packets:

```
00:00:03 tamago/arm (go1.23.1) • TEE security monitor (Secure World system/monitor) • b0a0fc8
00:00:03 Loaded OS from slot B
00:00:03 SM log verification pub: DEV-FT-LOG+22ab00a9+Ab6KRXXm5Hs9YuJWpNNlvlZ4BAisHRx7TR1375f7n5VZ
00:00:03 SM applet verification pub: DEV-APPLET+79441a79+Af/Q6S4XZtrNchMilwJK+YI3HAxE+0YqMMSznbOHdHXA
00:00:03 Loaded applet from slot A
00:00:03 SM Verifying applet bundle
00:00:06 SM Loaded applet version 0.2.1-24-ge90a715 (with TamaGo runtime 1.22.4)
00:00:06 SM Using legacy pre-1.23.0 wakeHandler
00:00:07 SM applet loaded addr:0x20000000 entry:0x20080368 size:16595800
00:00:07 SM applet started mode:USR sp:0x30000000 pc:0x20080368 ns:false
I0101 00:00:07.450053       3 main.go:131] tamago/arm (go1.22.4) • TEE user applet • e90a715
00:00:07 SM skipping applet version verification
00:00:07 SM starting network
I0101 00:00:07.486442       3 main.go:178] ----------------------------------------------------------- Trusted OS ----
I0101 00:00:07.495797       3 main.go:178] Serial number ..............: 720A9DEAD4391E1E
I0101 00:00:07.503527       3 main.go:178] Secure Boot ................: false
I0101 00:00:07.510386       3 main.go:178] SRK hash ...................:
I0101 00:00:07.516817       3 main.go:178] Revision ...................: b0a0fc8
I0101 00:00:07.523868       3 main.go:178] Version ....................: 0.2.0-25-gb0a0fc8
I0101 00:00:07.531781       3 main.go:178] Runtime ....................: go1.23.1 tamago/arm
I0101 00:00:07.539900       3 main.go:178] Link .......................: true
I0101 00:00:07.546830       3 main.go:178] MAC ........................: 4a:95:9d:bc:5a:5a
I0101 00:00:07.554600       3 main.go:178] IdentityCounter ............: 0
I0101 00:00:07.561104       3 main.go:178] Witness ....................: <no status>
I0101 00:00:07.568493       3 main.go:178] ----------------------------------------------------------- Trusted OS ----
I0101 00:00:07.886494       3 main.go:194] Attestation key:
DEV:AW-ID-Attestation-720A9DEAD4391E1E+ca59d820+AZhTXIbOHFbhQrHf22YK+4lLMsCfBrzA3zdA3IP5PaZh
I0101 00:00:07.898137       3 main.go:195] Attested identity key:
ArmoredWitness ID attestation v1
720A9DEAD4391E1E
0
DEV:ArmoredWitness-misty-snow+4235d37b+ATQcX3zXpdLJdudAP97VhTkO4m0DEyld9ndttS/XdIKq

— DEV:AW-ID-Attestation-720A9DEAD4391E1E ylnYIEjwPNzNhE6A6Mx/4zhes5Wxg+45gcCO9atyhu6bucDCrf/99BPSO4SQwdDxHAdPRod53cicvfgCXskTMMv/CgI=
I0101 00:00:07.942796       3 main.go:215] Opening storage...
I0101 00:00:07.951426       3 main.go:447] CardInfo: {MMC:true SD:false HC:true HS:true DDR:false Rate:150 BlockSize:512 Blocks:30576640 CID:[184 160 73 60 118 16 65 51 52 65 56 53 3 1 214 0]}
I0101 00:00:07.976023       3 main.go:217] Storage opened.
00:00:07 SM registering applet event handler g:0x20ddca28 p:0x20c2e008
I0101 00:00:08.055623       3 net.go:175] Starting DHCPClient...
I0101 00:00:08.594064       3 net.go:106] DHCPC: lease update - old: /0, new: 10.0.22.90/22
I0101 00:00:08.600836       3 net.go:137] DHCPC: Acquired 10.0.22.90/22
I0101 00:00:08.607158       3 net.go:189] DHCPC: Using DNS server(s) [10.0.20.1:53]
I0101 00:00:08.614277       3 net.go:201] DHCPC: Using Gateway 10.0.20.1
I0101 00:00:08.620888       3 net.go:157] DHCP: running f
```