### PR TITLE
Add wake handler support for go1.23 and go1.24

### DIFF
--- a/trusted_os/handler.s
+++ b/trusted_os/handler.s
@@ -15,17 +15,8 @@
 #include "go_asm.h"
 #include "textflag.h"
 
-// These defines are only used to aid applet runtime backward compatiblity,
-// within wakeHandlerPreGo123, and represent timer structs offsets fo Go <
-// 1.23.
-#define g_timer				208
-#define timer_nextwhen			36
-#define timer_status			44
-#define const_timerModifiedEarlier	7
-#define p_timerModifiedEarliest		2384
-
-// Supports tamago >= 1.23 applet runtime.
-TEXT ·wakeHandler(SB),$0-8
+// Supports tamago >= 1.24 applet runtime.
+TEXT ·wakeHandlerGo124(SB),$0-8
 	MOVW	handlerG+0(FP), R0
 	MOVW	handlerP+4(FP), R1
 
@@ -35,9 +26,148 @@ TEXT ·wakeHandler(SB),$0-8
 	CMP	$0, R1
 	B.EQ	done
 
+	// Call the current runtime's version of WakeG
 	B	runtime·WakeG(SB)
 done:
 	RET
+
+// These values are only used to aid applet runtime backward compatibility
+// within wakeHandlerGo123, and represent timer struct offsets in the Go runtime
+// for Go version 1.23.x
+//
+// To determine these values, the following rough process can be used:
+// 1. clone https://github.com/usbarmory/tamago-go@tamago-1.23.1
+// 2. cd tamago-go/src
+// 3. run ./all.bash to build the binaries
+// 4. within the cloned repo, create a file src/runtime/test.go with the following contents:
+//    package runtime
+//
+//    import "unsafe"
+//
+//    type Info struct {
+//            GTimer uintptr
+//    }
+//
+//    func GetInfo() Info {
+//            gp, _ := GetG()
+//            myG := (*g)(unsafe.Pointer(uintptr(gp)))
+//            r := Info{}
+//            r.GTimer = unsafe.Offsetof(myG.timer)
+//            return r
+//    }
+// 5. within the cloned repo, create a file test.go at the root with the following contents:
+//    package main
+//
+//    func main() {
+//            i := runtime.GetInfo()
+//            fmt.Printf("%#v", i)
+//    }
+// 6. From the root of the repo, run: GOOS=tamago GOARCH=arm ./bin/go run --work ./test.go
+//    This will fail with some "undefined: ..." errors, but importantly will print out a line line this:
+//    WORK=/tmp/go-build3974774761
+// 7. Find #define values of interest in /tmp/go-build3974774761/b002/go_asm.h
+
+#define go123_g_timer               212
+#define go123_timer_when             12
+#define go123_timerWhen__size        12
+#define go123_timerWhen_timer         0
+#define go123_timerWhen_when          4
+#define go123_timer_astate            4
+#define go123_timer_ts               44
+#define go123_timers_minWhenModified 40
+#define go123_timers_heap             4
+#define go123_const_timerModified     2
+
+// Supports tamago version >= 1.23.0 && < 1.24.
+TEXT ·wakeHandlerGo123(SB),$0-8
+	MOVW	handlerG+0(FP), R0
+	MOVW	handlerP+4(FP), R1
+
+	CMP	$0, R0
+	B.EQ	done
+
+	CMP	$0, R1
+	B.EQ	done
+
+	// Code below taken from tamago-go@1.23.1/src/runtime/sys_tamago_arm.s
+	MOVW	(go123_g_timer)(R0), R3
+	CMP	$0, R3
+	B.EQ	done
+
+	// g->timer.when = 1
+	MOVW	$1, R1
+	MOVW	R1, (go123_timer_when+0)(R3)
+	MOVW	$0, R1
+	MOVW	R1, (go123_timer_when+4)(R3)
+
+	// g->timer.astate &= timerModified
+	// g->timer.state  &= timerModified
+	MOVW	(go123_timer_astate)(R3), R2
+	ORR	$go123_const_timerModified<<8|go123_const_timerModified, R2, R2
+	MOVW	R2, (go123_timer_astate)(R3)
+
+	MOVW	(go123_timer_ts)(R3), R0
+	CMP	$0, R0
+	B.EQ	done
+
+	// g->timer.ts.minWhenModified = 1
+	MOVW	$1, R1
+	MOVW	R1, (go123_timers_minWhenModified+0)(R0)
+	MOVW	$0, R1
+	MOVW	R1, (go123_timers_minWhenModified+4)(R0)
+
+	// len(g->timer.ts.heap)
+	MOVW	(go123_timers_heap+4)(R0), R2
+	CMP	$0, R2
+	B.EQ	done
+
+	// offset to last element
+	SUB	$1, R2, R2
+	MOVW	$(go123_timerWhen__size), R1
+	MUL	R1, R2, R2
+
+	MOVW	(go123_timers_heap)(R0), R0
+	CMP	$0, R0
+	B.EQ	done
+
+	// g->timer.ts.heap[len-1]
+	ADD	R2, R0, R0
+	B	check
+
+prev:
+	SUB	$(go123_timerWhen__size), R0
+	CMP	$0, R0
+	B.EQ	done
+
+check:
+	// find longest timer as *timers.adjust() might be pending
+	MOVW	(go123_timerWhen_when+0)(R0), R1
+	CMP	$0xffffffff, R1 // LS word of math.MaxInt64
+	B.NE	prev
+
+	MOVW	(go123_timerWhen_when+4)(R0), R1
+	CMP	$0x7fffffff, R1 // MS word of math.MaxInt64
+	B.NE	prev
+
+	// g->timer.ts.heap[off] = 1
+	MOVW	$1, R1
+	MOVW	R1, (go123_timerWhen_when+0)(R0)
+	MOVW	$0, R1
+	MOVW	R1, (go123_timerWhen_when+4)(R0)
+
+done:
+	RET
+
+
+// These defines are only used to aid applet runtime backward compatiblity,
+// within wakeHandlerPreGo123, and represent timer structs offsets fo Go <
+// 1.23.
+#define go122_g_timer				208
+#define go122_timer_nextwhen			36
+#define go122_timer_status			44
+#define go122_const_timerModifiedEarlier	7
+#define go122_p_timerModifiedEarliest		2384
+
 
 // Supports tamago < 1.23 applet runtime.
 TEXT ·wakeHandlerPreGo123(SB),$0-8
@@ -50,24 +180,24 @@ TEXT ·wakeHandlerPreGo123(SB),$0-8
 	CMP	$0, R1
 	B.EQ	done
 
-	MOVW	(g_timer)(R0), R0
+	MOVW	(go122_g_timer)(R0), R0
 	CMP	$0, R0
 	B.EQ	done
 
 	// g->timer.nextwhen = 1
 	MOVW	$1, R2
-	MOVW	R2, (timer_nextwhen+0)(R0)
+	MOVW	R2, (go122_timer_nextwhen+0)(R0)
 	MOVW	$0, R2
-	MOVW	R2, (timer_nextwhen+4)(R0)
+	MOVW	R2, (go122_timer_nextwhen+4)(R0)
 
 	// g->timer.status = timerModifiedEarlier
-	MOVW	$const_timerModifiedEarlier, R2
-	MOVW	R2, (timer_status+0)(R0)
+	MOVW	$go122_const_timerModifiedEarlier, R2
+	MOVW	R2, (go122_timer_status+0)(R0)
 
 	// g->m->p.timerModifiedEarliest = 1
 	MOVW	$1, R2
-	MOVW	R2, (p_timerModifiedEarliest)(R1)
+	MOVW	R2, (go122_p_timerModifiedEarliest)(R1)
 	MOVW	$0, R2
-	MOVW	R2, (p_timerModifiedEarliest+4)(R1)
+	MOVW	R2, (go122_p_timerModifiedEarliest+4)(R1)
 done:
 	RET


### PR DESCRIPTION
This PR adds support for the monitor (when built with `tamago1.24`) to detect and correctly wake applets built with `tamago1.23` and `tamago1.24`.

Tested OS `tamago1.24`, Applet `tamago1.23`:
```
armored-witness-boot • tamago/arm (go1.23.1) • 3eefc3c • i.MX6UL
armored-witness-boot: version 0.1.0-35-g3eefc3c
armored-witness-boot: loading configuration & kernel at USDHC2@10485760
armored-witness-boot: log verifier: DEV-FT-LOG+22ab00a9+Ab6KRXXm5Hs9YuJWpNNlvlZ4BAisHRx7TR1375f7n5VZ
armored-witness-boot: kernel verifier: DEV-OS-1+23597896+AYFiM0rc8J6/64lwD85JQbNmE79dl0N8GBPRTZqT+VMe
armored-witness-boot: kernel verifier: DEV-OS-2+05022ebf+AcjbNE2bka89SEvmmgfAYZBA45cadsGUqUr7wh3XTdNx
armored-witness-boot: loaded kernel version 0.4.54
armored-witness-boot: verified kernel
armored-witness-boot00:00:03 tamago/arm (go1.24.1) • TEE security monitor (Secure World system/monitor) • 3637a8b
00:00:03 Loaded OS from slot B
00:00:03 SM log verification pub: DEV-FT-LOG+22ab00a9+Ab6KRXXm5Hs9YuJWpNNlvlZ4BAisHRx7TR1375f7n5VZ
00:00:03 SM applet verification pub: DEV-APPLET+79441a79+Af/Q6S4XZtrNchMilwJK+YI3HAxE+0YqMMSznbOHdHXA
00:00:04 Loaded applet from slot A
00:00:04 SM Verifying applet bundle
00:00:06 SM Loaded applet version 0.4.50 (with TamaGo runtime 1.23.1)
00:00:06 SM Using legacy 1.23.0 wakeHandler
00:00:07 SM applet loaded addr:0x20000000 entry:0x20086064 size:17322419
00:00:07 SM applet started mode:USR sp:0x30000000 pc:0x20086064 ns:false
I0101 00:00:07.719777       3 main.go:132] tamago/arm (go1.23.1) • TEE user applet • b29be38
```

Tested OS `tamago1.24`, Applet `tamago1.24`:
```
armored-witness-boot • tamago/arm (go1.23.1) • 3eefc3c • i.MX6UL
armored-witness-boot: version 0.1.0-35-g3eefc3c
armored-witness-boot: loading configuration & kernel at USDHC2@10485760
armored-witness-boot: log verifier: DEV-FT-LOG+22ab00a9+Ab6KRXXm5Hs9YuJWpNNlvlZ4BAisHRx7TR1375f7n5VZ
armored-witness-boot: kernel verifier: DEV-OS-1+23597896+AYFiM0rc8J6/64lwD85JQbNmE79dl0N8GBPRTZqT+VMe
armored-witness-boot: kernel verifier: DEV-OS-2+05022ebf+AcjbNE2bka89SEvmmgfAYZBA45cadsGUqUr7wh3XTdNx
armored-witness-boot: loaded kernel version 0.4.54
armored-witness-boot: verified kernel
armored-witness-boot00:00:03 tamago/arm (go1.24.1) • TEE security monitor (Secure World system/monitor) • 3637a8b
00:00:03 Loaded OS from slot B
00:00:03 SM log verification pub: DEV-FT-LOG+22ab00a9+Ab6KRXXm5Hs9YuJWpNNlvlZ4BAisHRx7TR1375f7n5VZ
00:00:03 SM applet verification pub: DEV-APPLET+79441a79+Af/Q6S4XZtrNchMilwJK+YI3HAxE+0YqMMSznbOHdHXA
00:00:04 Loaded applet from slot B
00:00:04 SM Verifying applet bundle
00:00:07 SM Loaded applet version 0.4.54 (with TamaGo runtime 1.24.1)
00:00:07 SM Using OS runtime 1.24.0 wakeHandler
00:00:07 SM applet loaded addr:0x20000000 entry:0x2008b8dc size:18199117
00:00:07 SM applet started mode:USR sp:0x30000000 pc:0x2008b8dc ns:false
I0101 00:00:07.789795       3 main.go:132] tamago/arm (go1.24.1) • TEE user applet • 3bc5bda
```
